### PR TITLE
Bug/215 GitHub actions clean up

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -1,12 +1,9 @@
 name: backend
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/backend.yaml'
       - 'backend/**'
       - '!**.md'
   workflow_dispatch:
@@ -98,32 +95,3 @@ jobs:
         with:
           name: jacoco-report
           path: backend/build/jacoco-report/
-
-  push-image:
-    name: Backend-Image
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/${{ github.repository }}-backend
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: backend
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/diveni-deploy.yml
+++ b/.github/workflows/diveni-deploy.yml
@@ -7,7 +7,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  push-image:
+  image-backend:
+    name: Backend-Docker-Image
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -17,25 +18,101 @@ jobs:
         uses: actions/checkout@v3
       - name: Verify files changed
         uses: tj-actions/verify-changed-files@v11
-        id: verify-files-changed
+        id: files-changed-backend
         with:
-          files: proxy
+          files: backend
       - name: Log in to the Container registry
+        if: steps.files-changed-backend.outputs.files_changed == 'true'
         uses: docker/login-action@v2
-        if: steps.verify-files-changed.outputs.files_changed == 'true'
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
+        if: steps.files-changed-backend.outputs.files_changed == 'true'
         id: meta
         uses: docker/metadata-action@v4
-        if: steps.verify-files-changed.outputs.files_changed == 'true'
+        with:
+          images: ghcr.io/${{ github.repository }}-backend
+          flavor: latest=true
+          tags: type=raw,value=latest,enable={{is_default_branch}}
+      - name: Build and push Docker image
+        if: steps.files-changed-backend.outputs.files_changed == 'true'
+        uses: docker/build-push-action@v3
+        with:
+          context: backend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  image-frontend:
+    name: Frontend-Docker-Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Verify files changed
+        uses: tj-actions/verify-changed-files@v11
+        id: files-changed-frontend
+        with:
+          files: frontend
+      - name: Log in to the Container registry
+        if: steps.files-changed-frontend.outputs.files_changed == 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.files-changed-frontend.outputs.files_changed == 'true'
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ghcr.io/${{ github.repository }}-frontend
+      - name: Build and push Docker image
+        if: steps.files-changed-frontend.outputs.files_changed == 'true'
+        uses: docker/build-push-action@v3
+        with:
+          context: frontend
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  image-proxy:
+    name: Proxy-Docker-Image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Verify files changed
+        uses: tj-actions/verify-changed-files@v11
+        id: files-changed-proxy
+        with:
+          files: proxy
+      - name: Log in to the Container registry
+        if: steps.files-changed-proxy.outputs.files_changed == 'true'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Extract metadata (tags, labels) for Docker
+        if: steps.files-changed-proxy.outputs.files_changed == 'true'
+        id: meta
+        uses: docker/metadata-action@v4
         with:
           images: ghcr.io/${{ github.repository }}-proxy
+          flavor: latest=true
+          tags: type=raw,value=latest,enable={{is_default_branch}}
       - name: Build and push Docker image
+        if: steps.files-changed-proxy.outputs.files_changed == 'true'
         uses: docker/build-push-action@v3
-        if: steps.verify-files-changed.outputs.files_changed == 'true'
         with:
           context: proxy
           push: true
@@ -44,23 +121,9 @@ jobs:
 
   deploy:
     name: Deploy to server
+    needs: [image-backend, image-frontend, image-proxy]
     runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     steps:
-      - name: Wait for backend workflow to succeed
-        uses: lewagon/wait-on-check-action@v1.1.2
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Backend-Image'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
-      - name: Wait for frontend workflow to succeed
-        uses: lewagon/wait-on-check-action@v1.1.2
-        with:
-          ref: ${{ github.ref }}
-          check-name: 'Frontend-Image'
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-          wait-interval: 10
       - name: Start application
         uses: appleboy/ssh-action@v0.1.1
         with:

--- a/.github/workflows/diveni-deploy.yml
+++ b/.github/workflows/diveni-deploy.yml
@@ -4,6 +4,10 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'backend/**'
+      - 'frontend/**'
+      - 'proxy/**'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/frontend.yaml
+++ b/.github/workflows/frontend.yaml
@@ -1,12 +1,9 @@
 name: frontend
 
 on:
-  push:
-    branches:
-      - main
   pull_request:
     paths:
-      - '.github/workflows/**'
+      - '.github/workflows/frontend.yaml'
       - 'frontend/**'
       - '!**.md'
   workflow_dispatch:
@@ -53,32 +50,3 @@ jobs:
         with:
           name: frontend
           path: frontend/dist
-
-  push-image:
-    name: Frontend-Image
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
-    if: github.ref == 'refs/heads/main'
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v3
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ghcr.io/${{ github.repository }}-frontend
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v3
-        with:
-          context: frontend
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/vuepress-deploy.yml
+++ b/.github/workflows/vuepress-deploy.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'docs/**'
 
 jobs:
   build-and-deploy:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3"
 
 services:
   database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3.8"
+version: "3"
 
 services:
   database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
     restart: unless-stopped
 
   backend:
-    image: ghcr.io/sybit-education/diveni-backend:main
+    image: ghcr.io/sybit-education/diveni-backend:latest
     depends_on:
       - database
     container_name: diveni_backend
@@ -18,14 +18,14 @@ services:
       - ./backend/.env
 
   frontend:
-    image: ghcr.io/sybit-education/diveni-frontend:main
+    image: ghcr.io/sybit-education/diveni-frontend:latest
     depends_on:
       - backend
     container_name: diveni_frontend
     restart: unless-stopped
 
   proxy:
-    image: ghcr.io/sybit-education/diveni-proxy:main
+    image: ghcr.io/sybit-education/diveni-proxy:latest
     depends_on:
       - frontend
       - backend

--- a/proxy/Dockerfile
+++ b/proxy/Dockerfile
@@ -1,5 +1,5 @@
 FROM nginx:stable
 
-COPY ./nginx.conf.template /etc/nginx/templates/
+COPY ./nginx.conf.template /etc/nginx/conf.d/default.conf
 
 EXPOSE 80


### PR DESCRIPTION
# Issue #215 

- Fix the issue that the reverse proxy was not set up correctly
- Set version from docker-compose from 3.8 to 3 to reduce compatibility problems
- Added global deployment workflow
>- Workflow that handles all docker images und deployment on [Diveni.io](https://diveni.io/)
>- Workflow only gets triggered at push on the main branch
- Remove lints, tests, etc at push on the main branch, because it is already done on sub branches
- Fix vuepress workflow by only allowing it to run when changed in `./docs/` were done