### PR TITLE
fix: swagger documentation (#285)

### DIFF
--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,3 +1,6 @@
 spring.data.mongodb.uri=mongodb://diveni_database:27017
 spring.data.mongodb.database=diveni
 server.port=9090
+springdoc.swagger-ui.disable-swagger-default-url=true
+springdoc.swagger-ui.configUrl=/api/v3/api-docs/swagger-config
+springdoc.swagger-ui.url=/api/v3/api-docs/

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -1,6 +1,7 @@
 spring.data.mongodb.uri=mongodb://diveni_database:27017
 spring.data.mongodb.database=diveni
 server.port=9090
+server.forward-headers-strategy=framework
 springdoc.swagger-ui.disable-swagger-default-url=true
 springdoc.swagger-ui.configUrl=/api/v3/api-docs/swagger-config
 springdoc.swagger-ui.url=/api/v3/api-docs/

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -3,5 +3,3 @@ spring.data.mongodb.database=diveni
 server.port=9090
 server.forward-headers-strategy=framework
 springdoc.swagger-ui.disable-swagger-default-url=true
-springdoc.swagger-ui.configUrl=/api/v3/api-docs/swagger-config
-springdoc.swagger-ui.url=/api/v3/api-docs/

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -33,13 +33,12 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_set_header X-Forwarded-Port $server_port;
+        proxy_set_header X-Forwarded-Prefix '/api';
 
         # Default in Spring Boot and required. Without it nginx suppresses the value
         proxy_pass_header X-XSRF-TOKEN;
 
-        # Set origin to the real instance, otherwise a of Spring security check will fail
-        # Same value as defined in proxy_pass
-        proxy_set_header Origin "http://backend:9090";
+        proxy_set_header Host $host;
         proxy_http_version 1.1;
         proxy_set_header Upgrade $http_upgrade;
         proxy_set_header Connection "upgrade";


### PR DESCRIPTION
# Issue #285 
## What
* Disable swagger petstore
* Set the correct paths when using Swagger behind a proxy
* Fix generated server url in Swagger

---
* Tested in a local dockerized environment