### PR TITLE
Feature/327 create vitepress docs build workflow to test for build errors

### DIFF
--- a/.github/workflows/docs-deploy.yaml
+++ b/.github/workflows/docs-deploy.yaml
@@ -7,6 +7,8 @@ on:
     paths:
       - '.github/workflows/docs-deploy.yaml'
       - 'docs/**'
+      - 'package.json'
+      - 'package-lock.json'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -5,6 +5,8 @@ on:
     paths:
       - '.github/workflows/docs.yaml'
       - 'docs/**'
+      - 'package.json'
+      - 'package-lock.json'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,23 @@
+name: Build Documentation
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/docs.yaml'
+      - 'docs/**'
+  workflow_dispatch:
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: npm
+      - run: npm ci
+      - name: Build
+        run: npm run docs:build


### PR DESCRIPTION
# Issue #327 
## What
* Add docs build workflow to test for build errors

## Fixes
* Add package.json and package-lock.json to all documentation-related workflows.