### PR TITLE
#393 User Stories are not fully clickable

### DIFF
--- a/frontend/src/components/UserStories.vue
+++ b/frontend/src/components/UserStories.vue
@@ -40,8 +40,8 @@
 
         <b-form-input
           v-model="story.title"
-          :disabled="true"
-          class="mx-1 w-100"
+          readonly
+          class="mx-1 w-100 shadow-none"
           size="sm"
           :placeholder="$t('page.session.before.userStories.placeholder.userStoryTitle')"
           @blur="publishChanges"


### PR DESCRIPTION
# Bug #393 
## Fix
* Fixes the bug where user stories are not fully clickable by changing the input field property from disabled to readonly.