### PR TITLE
 Fix: Graphical frontend elements/components are not loading properly #465 

### DIFF
--- a/frontend/src/components/ThemeToggleComponent.vue
+++ b/frontend/src/components/ThemeToggleComponent.vue
@@ -29,6 +29,8 @@ export default Vue.extend({
   created() {
     if (localStorage.getItem("user-theme")) {
       this.setTheme(localStorage.getItem("user-theme"));
+    } else {
+      this.setTheme(this.userTheme);
     }
   },
   methods: {


### PR DESCRIPTION
When visiting Diveni for the first time or with the cache cleared beforehand or in a private window, there is no "user-theme" item in the localStorage. To handle this case, we set the theme manually.
