### PR TITLE
Fix: Title text of the cardsets on the prepare page is not centered correctly #467 

### DIFF
--- a/frontend/src/components/CardSetComponent.vue
+++ b/frontend/src/components/CardSetComponent.vue
@@ -389,9 +389,10 @@ export default Vue.extend({
 }
 
 #text {
-  font-size: 20px;
+  font-size: 22px;
   font-weight: 500;
   padding-top: 16px;
+  text-align: center;
 }
 
 #cardDescription{


### PR DESCRIPTION
Setting the card set title alignment.