### PR TITLE
fix: "missing admin notifications" & "Uncaught Error: InvalidStateError" after session page refreshe

### DIFF
--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -34,16 +34,20 @@ export default new Vuex.Store<StoreState>({
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         state.stompClient.debug = () => {};
       }
-      state.stompClient.connect(
-        {},
-        () => {
-          state.webSocketConnected = true;
-        },
-        (error) => {
-          console.error(error);
-          state.webSocketConnected = false;
-        }
-      );
+      const connect_callback = function() {
+        console.log("WebSocket Connected");
+        state.webSocketConnected = true;
+      };
+      const error_callback = function(error) {
+        console.error("Error connecting to the WebSocket");
+        console.error(error);
+        state.webSocketConnected = false;
+      };
+      /**
+       * client.connect(headers, connectCallback, errorCallback);
+       * More information here: https://jmesnil.net/stomp-websocket/doc/
+       */
+      state.stompClient.connect({}, connect_callback, error_callback);
     },
     subscribeOnBackendWSMemberUpdates(state) {
       state.stompClient?.subscribe(Constants.webSocketMemberListenRoute, (frame) => {

--- a/frontend/src/views/SessionPage.vue
+++ b/frontend/src/views/SessionPage.vue
@@ -430,15 +430,13 @@ export default Vue.extend({
           this.registerAdminPrincipalOnBackend();
           this.subscribeWSMemberUpdated();
           this.subscribeOnTimerStart();
-          if (this.rejoined === "false") {
-            this.subscribeWSNotification();
-          }
+          this.subscribeWSNotification();
           if (this.startNewSessionOnMountedString === "true") {
             this.sendRestartMessage();
           }
           setTimeout(() => {
             this.requestMemberUpdate();
-          }, 600);
+          }, 400);
         }, 300);
       }
     },
@@ -480,10 +478,12 @@ export default Vue.extend({
     window.addEventListener("beforeunload", this.sendUnregisterCommand);
   },
   mounted() {
+    if (this.rejoined === "false") {
+      this.connectToWebSocket();
+    }
     if (this.session_voteSetJson) {
       this.voteSet = JSON.parse(this.session_voteSetJson);
     }
-    this.connectToWebSocket();
     if (this.session_sessionState === Constants.memberUpdateCommandStartVoting) {
       this.planningStart = true;
     } else if (this.session_sessionState === Constants.memberUpdateCommandVotingFinished) {
@@ -573,9 +573,6 @@ export default Vue.extend({
       this.timerCountdownNumber = parseInt(this.session_timerSecondsString, 10);
       //reconnect and reload member
       this.connectToWebSocket();
-      setTimeout(() => {
-        this.subscribeWSNotification();
-      }, 300);
     },
     async onUserStoriesChanged({ us, idx, doRemove }) {
       console.log(`stories: ${us}`);


### PR DESCRIPTION
Fix for:  #536 and #540 

- Simplified the readability of the WebSocket connection mutation/function
- Prevented the WebSocket from reopening multiple times after a refresh and removed the subscribeWSNotification() from the handleReload() function to ensure that WS subscriptions only occur within the 'watch,' guaranteeing that the WebSocket is open

Also those changes are currently deployed on dev.diveni for testing purposes.
            