### PR TITLE
Fix: Project Selection Component clickable only after input #561 

### DIFF
--- a/frontend/src/components/ProjectSelectionComponent.vue
+++ b/frontend/src/components/ProjectSelectionComponent.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div ref="projectSelectionRef">
     <b-input-group>
       <b-input-group-prepend>
         <b-input-group-text><BIconSearch id="searchIcon"></BIconSearch></b-input-group-text>
@@ -14,14 +14,12 @@
           )
         "
         @input="
+          filterProjects();
+        "
+        @focus="
           showResult = true;
           filterProjects();
         "
-        @click="
-          showResult = true;
-          filterProjects();
-        "
-        @blur="input === '' ? (showResult = false) : (showResult = true)"
       />
     </b-input-group>
     <ul v-if="showResult" class="vue-autocomplete-input-tag-items">
@@ -72,16 +70,27 @@ export default defineComponent({
       return this.store.projects;
     },
   },
-
+  mounted() {
+    document.addEventListener("click", this.handleGlobalClick);
+  },
+  beforeUnmount() {
+    document.removeEventListener("click", this.handleGlobalClick);
+  },
   methods: {
+    handleGlobalClick(event: MouseEvent) {
+      const isOutsideComponent = !(this.$refs.projectSelectionRef as HTMLElement).contains(
+        event.target as Node
+      );
+      if (isOutsideComponent) {
+        this.showResult = false;
+      }
+    },
     async getUserStories() {
       this.aCorrectProject = false;
       const selectedProject = this.projects.find((p) => p.name === this.selected);
       if (selectedProject) {
         this.aCorrectProject = true;
-        console.log(`Selected: ${selectedProject}`);
         this.store.setSelectedProject(selectedProject);
-        console.log(`Selected Project: ${this.selected}`);
         const response = await apiService.getUserStoriesFromProject(this.selected);
         this.store.setUserStories({ stories: response });
       }
@@ -106,13 +115,12 @@ export default defineComponent({
       return this.projects.map((p) => p.name);
     },
     selectProject(name: string) {
-      this.projects.forEach((project) => {
-        if (project.name === name) {
-          this.selected = project.name;
-        }
-      });
-      this.input = this.selected;
-      this.getUserStories();
+      const project = this.projects.find((p) => p.name === name);
+      if (project) {
+        this.selected = project.name;
+        this.input = this.selected;
+        this.getUserStories();
+      }
     },
   },
 });

--- a/frontend/src/components/ProjectSelectionComponent.vue
+++ b/frontend/src/components/ProjectSelectionComponent.vue
@@ -115,12 +115,13 @@ export default defineComponent({
       return this.projects.map((p) => p.name);
     },
     selectProject(name: string) {
-      const project = this.projects.find((p) => p.name === name);
-      if (project) {
-        this.selected = project.name;
-        this.input = this.selected;
-        this.getUserStories();
-      }
+      this.projects.forEach((project) => {
+        if (project.name === name) {
+          this.selected = project.name;
+        }
+      });
+      this.input = this.selected;
+      this.getUserStories();
     },
   },
 });


### PR DESCRIPTION
Fix for: #561

The issue was that when clicking out of the input field and selecting the project, the `@blur` event triggered too quickly, disallowing the selection of a project.
Now, I've implemented an EventListener that checks whether there was a click outside the ProjectSelectionComponent. 
If so, it sets showResult to false. Alternatively, if a project is clicked, it first selects the project and then sets showResult to false.

There probably is a more elegant and simpler solution... If you have a simpler solution for this, I'm all ears! 😄 

If we were to use an autocomplete/search-select library, we also could significantly reduce the amount of code as well.