### PR TITLE
Persist MongoDB data with Docker-managed volumes.

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -5,7 +5,7 @@ services:
     image: mongo:latest
     container_name: diveni_database
     volumes:
-      - /mongo/data:/data/db
+      - mongo-volume:/data/db
     restart: unless-stopped
 
   backend:
@@ -38,3 +38,6 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+
+volumes:
+  mongo-volume:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -2,8 +2,10 @@ version: "3"
 
 services:
   database:
-    image: mongo:4
+    image: mongo:latest
     container_name: diveni_database
+    volumes:
+      - /mongo/data:/data/db
     restart: unless-stopped
 
   backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,8 +2,10 @@ version: "3"
 
 services:
   database:
-    image: mongo:4
+    image: mongo:latest
     container_name: diveni_database
+    volumes:
+      - /mongo/data:/data/db
     restart: unless-stopped
 
   backend:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: mongo:latest
     container_name: diveni_database
     volumes:
-      - /mongo/data:/data/db
+      - mongo-volume:/data/db
     restart: unless-stopped
 
   backend:
@@ -36,3 +36,6 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+
+volumes:
+  mongo-volume:


### PR DESCRIPTION
Currently, performing a `docker-compose down` (container deletion) or a change to the image results in data loss.

- I have now implemented a solution where our MongoDB data is persisted via Docker-managed volumes, which is crucial for reliably displaying our statistics
- As part of this, I also updated MongoDB to the latest version
