### PR TITLE
Implementation of Docker health checks

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-ui:1.7.0'
     implementation 'org.apache.httpcomponents:httpclient:4.5.14'
     implementation 'org.json:json:20230227'
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'de.flapdoodle.embed:de.flapdoodle.embed.mongo.spring31x:4.11.0'

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 
 services:
   database:
@@ -7,6 +7,12 @@ services:
     volumes:
       - mongo-volume:/data/db
     restart: unless-stopped
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/diveni --quiet
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
 
   backend:
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -44,6 +44,12 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+    healthcheck:
+      test: curl --fail http://localhost/health || exit 1
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
 
 volumes:
   mongo-volume:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
     env_file:
       - ./backend/.env
     healthcheck:
-      test: curl --fail localhost:9090/actuator/health | grep UP || exit 1
+      test: curl --fail http://backend:9090/actuator/health | grep UP || exit 1
       interval: 60s
       timeout: 30s
       retries: 3
@@ -39,6 +39,12 @@ services:
       ./frontend
     container_name: diveni_frontend
     restart: unless-stopped
+    healthcheck:
+      test: curl --fail http://frontend:80 || exit 1
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
 
   proxy:
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -25,6 +25,12 @@ services:
       - "SPRING_PROFILES_ACTIVE=prod"
     env_file:
       - ./backend/.env
+    healthcheck:
+      test: "curl --fail --silent localhost:9090/actuator/health | grep UP || exit 1"
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
 
   frontend:
     depends_on:

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
     env_file:
       - ./backend/.env
     healthcheck:
-      test: curl --fail --silent localhost:9090/actuator/health | grep UP || exit 1
+      test: curl --fail localhost:9090/actuator/health | grep UP || exit 1
       interval: 60s
       timeout: 30s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -26,7 +26,7 @@ services:
     env_file:
       - ./backend/.env
     healthcheck:
-      test: "curl --fail --silent localhost:9090/actuator/health | grep UP || exit 1"
+      test: curl --fail --silent localhost:9090/actuator/health | grep UP || exit 1
       interval: 60s
       timeout: 30s
       retries: 3
@@ -51,7 +51,7 @@ services:
     ports:
       - "80:80"
     healthcheck:
-      test: curl --fail http://localhost:80/health || exit 1
+      test: curl --fail http://localhost:80/health | grep UP || exit 1
       interval: 60s
       timeout: 30s
       retries: 3

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -51,7 +51,7 @@ services:
     ports:
       - "80:80"
     healthcheck:
-      test: curl --fail http://localhost/health || exit 1
+      test: curl --fail http://localhost:80/health || exit 1
       interval: 60s
       timeout: 30s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: "3.4"
 
 services:
   database:
@@ -7,6 +7,12 @@ services:
     volumes:
       - mongo-volume:/data/db
     restart: unless-stopped
+    healthcheck:
+      test: echo 'db.runCommand("ping").ok' | mongosh localhost:27017/diveni --quiet
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
 
   backend:
     image: ghcr.io/sybit-education/diveni-backend:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,12 @@ services:
       - "SPRING_PROFILES_ACTIVE=prod"
     env_file:
       - ./backend/.env
+    healthcheck:
+      test: "curl --fail --silent localhost:9090/actuator/health | grep UP || exit 1"
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
 
   frontend:
     image: ghcr.io/sybit-education/diveni-frontend:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     env_file:
       - ./backend/.env
     healthcheck:
-      test: curl --fail --silent localhost:9090/actuator/health | grep UP || exit 1
+      test: curl --fail localhost:9090/actuator/health | grep UP || exit 1
       interval: 60s
       timeout: 30s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     env_file:
       - ./backend/.env
     healthcheck:
-      test: curl --fail localhost:9090/actuator/health | grep UP || exit 1
+      test: curl --fail http://backend:9090/actuator/health | grep UP || exit 1
       interval: 60s
       timeout: 30s
       retries: 3
@@ -37,6 +37,12 @@ services:
       - backend
     container_name: diveni_frontend
     restart: unless-stopped
+    healthcheck:
+      test: curl --fail http://frontend:80 || exit 1
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
 
   proxy:
     image: ghcr.io/sybit-education/diveni-proxy:latest

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -49,7 +49,7 @@ services:
     ports:
       - "80:80"
     healthcheck:
-      test: curl --fail http://localhost/health || exit 1
+      test: curl --fail http://localhost:80/health || exit 1
       interval: 60s
       timeout: 30s
       retries: 3

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,12 @@ services:
     restart: unless-stopped
     ports:
       - "80:80"
+    healthcheck:
+      test: curl --fail http://localhost/health || exit 1
+      interval: 60s
+      timeout: 30s
+      retries: 3
+      start_period: 30s
 
 volumes:
   mongo-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,7 +25,7 @@ services:
     env_file:
       - ./backend/.env
     healthcheck:
-      test: "curl --fail --silent localhost:9090/actuator/health | grep UP || exit 1"
+      test: curl --fail --silent localhost:9090/actuator/health | grep UP || exit 1
       interval: 60s
       timeout: 30s
       retries: 3
@@ -49,7 +49,7 @@ services:
     ports:
       - "80:80"
     healthcheck:
-      test: curl --fail http://localhost:80/health || exit 1
+      test: curl --fail http://localhost:80/health | grep UP || exit 1
       interval: 60s
       timeout: 30s
       retries: 3

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -51,4 +51,11 @@ server {
     location = /404.html {
         internal;
     }
+
+    # Proxy Container HealthCheck
+    location = /health {
+        access_log off;
+        add_header 'Content-Type' 'application/json';
+        return 200 '{"status":"UP"}';
+    }
 }


### PR DESCRIPTION
PR for: #681
Checks every 60 seconds if the server is running properly within Docker.
If you want to test it in a local Docker setup, you'll need to start it by running `docker-compose -f docker-compose.dev.yml up --build -d`, as I've made changes to the nginx.conf file and the backend.

![Healthcheck](https://github.com/Sybit-Education/Diveni/assets/142214610/ae6c7ff5-751e-46cc-8266-26f61f5e8d54)
