### PR TITLE
Fix: Deleting User Stories while using Jira Server doesn't work #715 

### DIFF
--- a/backend/src/main/java/io/diveni/backend/service/projectmanagementproviders/jiraserver/JiraServerService.java
+++ b/backend/src/main/java/io/diveni/backend/service/projectmanagementproviders/jiraserver/JiraServerService.java
@@ -34,6 +34,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -104,12 +105,12 @@ public class JiraServerService implements ProjectManagementProviderOAuth1 {
       GenericUrl jiraUrl,
       String requestMethod,
       HttpContent content,
-      String contentType)
+      MediaType contentType)
       throws IOException {
     HttpRequestFactory requestFactory = new NetHttpTransport().createRequestFactory(parameters);
     HttpRequest request = requestFactory.buildRequest(requestMethod, jiraUrl, content);
     if (contentType != null) {
-      request.getHeaders().setContentType(contentType);
+      request.getHeaders().setContentType(contentType.toString());
     }
     return request.execute();
   }
@@ -334,7 +335,7 @@ public class JiraServerService implements ProjectManagementProviderOAuth1 {
               new GenericUrl(getJiraUrl() + "/issue/" + issueID),
               "DELETE",
               null,
-              "application/json");
+              MediaType.APPLICATION_JSON);
 
       LOGGER.debug("<-- deleteIssue() {}", response.parseAsString());
     } catch (Exception e) {

--- a/backend/src/main/java/io/diveni/backend/service/projectmanagementproviders/jiraserver/JiraServerService.java
+++ b/backend/src/main/java/io/diveni/backend/service/projectmanagementproviders/jiraserver/JiraServerService.java
@@ -100,8 +100,12 @@ public class JiraServerService implements ProjectManagementProviderOAuth1 {
    * @throws IOException
    */
   private static HttpResponse getResponseFromUrl(
-    OAuthParameters parameters, GenericUrl jiraUrl, String requestMethod,
-    HttpContent content, String contentType) throws IOException {
+      OAuthParameters parameters,
+      GenericUrl jiraUrl,
+      String requestMethod,
+      HttpContent content,
+      String contentType)
+      throws IOException {
     HttpRequestFactory requestFactory = new NetHttpTransport().createRequestFactory(parameters);
     HttpRequest request = requestFactory.buildRequest(requestMethod, jiraUrl, content);
     if (contentType != null) {
@@ -166,7 +170,8 @@ public class JiraServerService implements ProjectManagementProviderOAuth1 {
       OAuthParameters parameters =
           jiraOAuthClient.getParameters(accessToken, CONSUMER_KEY, PRIVATE_KEY);
       HttpResponse response =
-          getResponseFromUrl(parameters, new GenericUrl(getJiraUrl() + "/project"), "GET", null, null);
+          getResponseFromUrl(
+              parameters, new GenericUrl(getJiraUrl() + "/project"), "GET", null, null);
       ObjectNode[] node =
           new ObjectMapper().readValue(response.parseAsString(), ObjectNode[].class);
 
@@ -208,7 +213,8 @@ public class JiraServerService implements ProjectManagementProviderOAuth1 {
                       + ESTIMATION_FIELD
                       + "&maxResults=1000"),
               "GET",
-              null, null);
+              null,
+              null);
       // The reply from the Jira API is no correct JSON, therefore [ and ] have to be
       // added
       val json = "[" + response.parseAsString() + "]";
@@ -271,7 +277,8 @@ public class JiraServerService implements ProjectManagementProviderOAuth1 {
               parameters,
               new GenericUrl(getJiraUrl() + "/issue/" + story.getId()),
               "PUT",
-              new JsonHttpContent(GsonFactory.getDefaultInstance(), content), null);
+              new JsonHttpContent(GsonFactory.getDefaultInstance(), content),
+              null);
 
       LOGGER.debug("<-- updateIssue() {}", response.parseAsString());
     } catch (Exception e) {
@@ -300,7 +307,8 @@ public class JiraServerService implements ProjectManagementProviderOAuth1 {
               parameters,
               new GenericUrl(getJiraUrl() + "/issue"),
               "POST",
-              new JsonHttpContent(GsonFactory.getDefaultInstance(), content), null);
+              new JsonHttpContent(GsonFactory.getDefaultInstance(), content),
+              null);
 
       JsonNode node = new ObjectMapper().readTree(response.parseAsString());
       LOGGER.debug("<-- createIssue()");
@@ -324,9 +332,9 @@ public class JiraServerService implements ProjectManagementProviderOAuth1 {
           getResponseFromUrl(
               parameters,
               new GenericUrl(getJiraUrl() + "/issue/" + issueID),
-            "DELETE",
-            null,
-            "application/json");
+              "DELETE",
+              null,
+              "application/json");
 
       LOGGER.debug("<-- deleteIssue() {}", response.parseAsString());
     } catch (Exception e) {
@@ -346,7 +354,11 @@ public class JiraServerService implements ProjectManagementProviderOAuth1 {
               accessTokens.get(tokenIdentifier), CONSUMER_KEY, PRIVATE_KEY);
       HttpResponse response =
           getResponseFromUrl(
-              parameters, new GenericUrl(JIRA_HOME + "/rest/auth/latest/session"), "GET", null, null);
+              parameters,
+              new GenericUrl(JIRA_HOME + "/rest/auth/latest/session"),
+              "GET",
+              null,
+              null);
       String res = response.parseAsString();
       JsonNode node = new ObjectMapper().readTree(res);
       LOGGER.debug("<-- getCurrentUsername()");


### PR DESCRIPTION
Fix for #715 

The getResponseFromUrl method can now independently determine the required content type needed to properly delete user stories.