### PR TITLE
Fix:  Uncaught SyntaxError: Unexpected token '<' after deployments #674 

### DIFF
--- a/frontend/vue.config.js
+++ b/frontend/vue.config.js
@@ -1,3 +1,5 @@
+const path = require("path");
+
 module.exports = {
   pwa: {
     name: "Diveni",
@@ -5,19 +7,25 @@ module.exports = {
     msTileColor: "#000000",
     appleMobileWebAppCapable: "yes",
     appleMobileWebAppStatusBarStyle: "black",
+    workboxOptions: {
+      exclude: [/index.html$/],
+    },
   },
   configureWebpack: {
+    output: {
+      filename: "[name].[contenthash].js",
+      path: path.resolve(__dirname, "dist"),
+      clean: true,
+    },
     optimization: {
+      moduleIds: "deterministic",
+      runtimeChunk: "single",
       splitChunks: {
         cacheGroups: {
           vendor: {
             test: /[\\/]node_modules[\\/]/,
-            name: "vendor",
+            name: "vendors",
             chunks: "all",
-            enforce: true,
-            priority: 1,
-            maxInitialRequests: 3,
-            maxAsyncRequests: 5, // hier wird die Anzahl der gleichzeitigen Anfragen für nachfolgende Chunk-Dateien begrenzt
           },
         },
       },

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -17,6 +17,18 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
+        if ( $uri = '/index.html' ) {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Pragma "no-cache";
+            expires off;
+        }
+
+        if ($http_accept ~* "text/html") {
+            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Pragma "no-cache";
+            expires off;
+        }
+
         expires 1d;
         add_header Cache-Control "public, max-age=86400, immutable";
     }
@@ -50,12 +62,5 @@ server {
     # You may need this to prevent return 404 recursion.
     location = /404.html {
         internal;
-    }
-
-    # Proxy Container HealthCheck
-    location = /health {
-        access_log off;
-        add_header 'Content-Type' 'application/json';
-        return 200 '{"status":"UP"}';
     }
 }

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -18,13 +18,13 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
         if ( $uri = '/index.html' ) {
-            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Cache-Control "max-age=0, no-cache, no-store, must-revalidate";
             add_header Pragma "no-cache";
             expires off;
         }
 
         if ($http_accept ~* "text/html") {
-            add_header Cache-Control "no-cache, no-store, must-revalidate";
+            add_header Cache-Control "max-age=0, no-cache, no-store, must-revalidate";
             add_header Pragma "no-cache";
             expires off;
         }

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -17,20 +17,15 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
 
-        if ( $uri = '/index.html' ) {
-            add_header Cache-Control "max-age=0, no-cache, no-store, must-revalidate";
-            add_header Pragma "no-cache";
-            expires off;
+        # Everything we want to cache
+        if ( $uri ~* \.(js|css|png|jpg|jpeg|gif|svg|ico)$ ) {
+            add_header Cache-Control "public, max-age=31536000, immutable";
         }
 
-        if ($http_accept ~* "text/html") {
-            add_header Cache-Control "max-age=0, no-cache, no-store, must-revalidate";
-            add_header Pragma "no-cache";
-            expires off;
-        }
-
-        expires 1d;
-        add_header Cache-Control "public, max-age=86400, immutable";
+        # The rest should not be cached(e.g. index.html)
+        add_header Cache-Control "private, max-age=0, no-cache, no-store, must-revalidate";
+        add_header Pragma "no-cache";
+        expires off;
     }
 
     location ~ /proxy/(http://.*) {

--- a/proxy/nginx.conf.template
+++ b/proxy/nginx.conf.template
@@ -63,4 +63,11 @@ server {
     location = /404.html {
         internal;
     }
+
+    # Proxy Container HealthCheck
+    location = /health {
+        access_log off;
+        add_header 'Content-Type' 'application/json';
+        return 200 '{"status":"UP"}';
+    }
 }


### PR DESCRIPTION
We likely encountered a similar issue as explained in the following section of the blog:

https://elelad.medium.com/avoid-cache-trap-when-serving-angular-app-c5981653d156

>To avoid cache issues in our Angular application and manage app versioning, when we are building our app to production using ng build --prod Angular adds (by default) a hash to our js files and updates our index.html file to refer to the hash files. When we deploy a new version, the hash keys are changed, and when the user asks the site again, the index.html will ask to load the new files from the server. Since the browser doesn't have those files in the cache, it will get them from the server.

>So it looks like Angular guys cover us? Well, not entirely. The problems are starting when the index.html file is cached. Let’s say we just deployed a new version of our app, and the static files, and index.html file with them, are cached. In this scenario, when the user is starting to use our app from the main URL, he is getting the old version of our app because the cached index.html asks to load the old js files, and they will probably load from the browser cache.


The Uncaught SyntaxError: Unexpected token '<' occurred subsequently when we deployed tird-party code changes, such as dependency updates, causing the hash in the name of the vendor.js to change and after one day, the browser attempted to refresh the old vendor.js due to the NGINX configuration(`expires 1d;
add_header Cache-Control "public, max-age=86400, immutable";
`), but couldn't find it anymore also due to the also cached index.html and redirected again to the old the index.html, which starts with `<!DOCTYPE html>`. 

Since the first character is '<' and it actually expected JavaScript instead of html, the Uncaught SyntaxError: Unexpected token '<' occurs.


I've tried removing the index.html from caching now. Hopefully, this will finally fix the bug.
If you have any other suggestions on how to fix the bug, please feel free to share them!


Similar Problem/Solution: https://tech.competa.com/proper-cache-busting-for-index-html-apache-b07797322f29