### PR TITLE
Fix: Session admin's user story filter affects the filter of the members #734 

### DIFF
--- a/frontend/src/components/UserStories.vue
+++ b/frontend/src/components/UserStories.vue
@@ -149,6 +149,7 @@ export default defineComponent({
       handler(newStories) {
         this.userStories = newStories;
         this.savedStories = newStories;
+        this.filterStories();
       },
     },
     hostSelectedStoryIndex(newIndex) {
@@ -203,12 +204,7 @@ export default defineComponent({
     },
     deleteStory(index: number) {
       const originalIndex = this.getOriginalIndex(index);
-      if (this.filterActive) {
-        this.filteredStories.splice(index, 1);
-        this.displayedStories.splice(index, 1);
-      }
       this.publishChanges(originalIndex, true);
-      this.filterStories();
     },
     publishChanges(index: number, remove: boolean) {
       this.$emit("userStoriesChanged", { us: this.savedStories, idx: index, doRemove: remove });

--- a/frontend/src/components/UserStories.vue
+++ b/frontend/src/components/UserStories.vue
@@ -24,14 +24,14 @@
         :style="getOriginalIndex(index) === selectedStoryIndex ? 'border-width: 3px;' : ''"
         @mouseover="hover = index"
         @mouseleave="hover = null"
-        @click.stop="setUserStoryAsActive(index)"
+        @click="setUserStoryAsActive(index)"
       >
         <b-button
           v-if="showEditButtons"
           variant="primary"
           :class="story.isActive ? 'selectedStory' : 'outlineColorStory'"
           size="sm"
-          @click.stop="
+          @click="
             markUserStory(index);
             $event.target.blur();
           "


### PR DESCRIPTION
Fix for: #734 

I have restructured the UserStories.vue component so that only the processes of adding and deleting user stories, as well as displaying the active user story are synchronized with other members. 
The filtering process should no longer be synchronized with other members, meaning each member can independently use the filter function and browse through the user stories.

Since I have made several changes/restructuring to the component, we should thoroughly test it before merging.