### PR TITLE
Fix:  Deleting User Stories in "Planning with User Stories"-Mode Swaps Titles and Descriptions of remaining Stories #778 

### DIFF
--- a/frontend/src/components/UserStories.vue
+++ b/frontend/src/components/UserStories.vue
@@ -114,8 +114,6 @@ import { defineComponent } from "vue";
 import UserStory from "../model/UserStory";
 import { useI18n } from "vue-i18n";
 
-const generatedUUIDs = new Set<number>();
-
 export default defineComponent({
   name: "UserStories",
   props: {
@@ -139,6 +137,7 @@ export default defineComponent({
       input: "",
       filterActive: false,
       savedStories: [] as Array<UserStory>,
+      generatedUUIDs: new Set<number>(),
     };
   },
   watch: {
@@ -218,8 +217,8 @@ export default defineComponent({
       let uuid: number;
       do {
         uuid = Math.floor(Math.random() * 1e15) + Date.now();
-      } while (generatedUUIDs.has(uuid));
-      generatedUUIDs.add(uuid);
+      } while (this.generatedUUIDs.has(uuid));
+      this.generatedUUIDs.add(uuid);
       return uuid;
     },
   },

--- a/frontend/src/components/UserStories.vue
+++ b/frontend/src/components/UserStories.vue
@@ -124,6 +124,7 @@ export default defineComponent({
     showEstimations: { type: Boolean, required: true },
     showEditButtons: { type: Boolean, required: false, default: true },
     hostSelectedStoryIndex: { type: Number, required: false, default: null },
+    storyMode: { type: String, required: false, default: null },
   },
   setup() {
     const { t } = useI18n();
@@ -159,7 +160,7 @@ export default defineComponent({
     },
     addUserStory() {
       const story: UserStory = {
-        id: this.generateNumericUUID(),
+        id: this.storyMode === "US_JIRA" ? null : this.generateNumericUUID(),
         title: "",
         description: "",
         estimation: null,

--- a/frontend/src/components/UserStories.vue
+++ b/frontend/src/components/UserStories.vue
@@ -114,6 +114,8 @@ import { defineComponent } from "vue";
 import UserStory from "../model/UserStory";
 import { useI18n } from "vue-i18n";
 
+const generatedUUIDs = new Set<number>();
+
 export default defineComponent({
   name: "UserStories",
   props: {
@@ -157,7 +159,7 @@ export default defineComponent({
     },
     addUserStory() {
       const story: UserStory = {
-        id: null,
+        id: this.generateNumericUUID(),
         title: "",
         description: "",
         estimation: null,
@@ -210,6 +212,14 @@ export default defineComponent({
       stories[index].isActive = true;
       this.userStories = stories;
       this.publishChanges(index, false);
+    },
+    generateNumericUUID() {
+      let uuid: number;
+      do {
+        uuid = Math.floor(Math.random() * 1e15) + Date.now();
+      } while (generatedUUIDs.has(uuid));
+      generatedUUIDs.add(uuid);
+      return uuid;
     },
   },
 });

--- a/frontend/src/views/SessionPage.vue
+++ b/frontend/src/views/SessionPage.vue
@@ -256,6 +256,7 @@
           :initial-stories="userStories"
           :show-edit-buttons="true"
           :select-story="true"
+          :story-mode="userStoryMode"
           @userStoriesChanged="onUserStoriesChanged"
           @selectedStory="onSelectedStory($event)"
         />
@@ -279,6 +280,7 @@
           :initial-stories="userStories"
           :show-edit-buttons="true"
           :select-story="true"
+          :story-mode="userStoryMode"
           @userStoriesChanged="onUserStoriesChanged"
           @selectedStory="onSelectedStory($event)"
         />


### PR DESCRIPTION
Fix for: #778 

The problem is that in 'Planning with User Stories'-mode, we do not assign an ID to our user stories. 
Therefore, in the UserStoryDescriptions.vue, the key attribute: (:key="story.id") does not work which leads to the titles and descriptions not being aligned after deletion.
