### PR TITLE
Fix:  Default value for time should be infinite #798 

### DIFF
--- a/frontend/src/components/EstimateTimer.vue
+++ b/frontend/src/components/EstimateTimer.vue
@@ -63,7 +63,10 @@ export default defineComponent({
   },
   methods: {
     formatTimer() {
-      if (this.startTimestamp === "" || this.duration === 0) {
+      if (this.duration === 0) {
+        return "∞";
+      }
+      if (this.startTimestamp === "") {
         return "";
       }
       const minutes = Math.floor(this.timerCount / 60);

--- a/frontend/src/views/PrepareSessionPage.vue
+++ b/frontend/src/views/PrepareSessionPage.vue
@@ -282,7 +282,7 @@ export default defineComponent({
         activeValues: [] as string[],
         position: 0,
       } as CardSet,
-      timer: 30,
+      timer: 0,
       warningWhenUnderZero: "",
       tabIndex: null as number | null,
       hostVoting: false,


### PR DESCRIPTION
Fix for: #798 

The default value should now be set to infinite, and in our clock animation, we now also display the infinite symbol if active.

