### PR TITLE
Fix: The markdown editor gpt button is not displayed #819 

### DIFF
--- a/frontend/src/components/MarkdownEditor.vue
+++ b/frontend/src/components/MarkdownEditor.vue
@@ -113,9 +113,9 @@ export default defineComponent({
     },
   },
   setup() {
-    const { locale } = useI18n();
+    const { t, locale } = useI18n();
     const currentLocale = ref(locale.value);
-    return { currentLocale };
+    return { t, currentLocale };
   },
   data() {
     return {


### PR DESCRIPTION
Readded missing internationalization translate funtion