### PR TITLE
Improve estimation timer

### DIFF
--- a/frontend/src/components/EstimateTimer.vue
+++ b/frontend/src/components/EstimateTimer.vue
@@ -1,134 +1,134 @@
 <template>
   <div class="d-flex justify-content-end estimate-timer">
     <b-card-text :style="`color: ${textColor}`" class="timer">
-      {{ formatTimer() }}
+      {{ formattedTime }}
     </b-card-text>
   </div>
 </template>
 
-<script lang="ts">
-import constants from "@/constants";
-import { defineComponent } from "vue";
-import axios from "axios";
+<script setup lang="ts">
+import { ref, computed, watch, onBeforeUnmount } from "vue";
 
-export default defineComponent({
-  name: "EstimateTimer",
-  props: {
-    startTimestamp: { type: String, required: true },
-    duration: { type: Number, required: true },
-    pauseTimer: { type: Boolean, required: true },
-    member: { type: String, required: false, default: "" },
-    votingStarted: { type: Boolean, required: true },
-  },
-  emits: ["timerFinished"],
-  data() {
-    return {
-      timerCount: 0,
-      intervalHandler: -1,
-    };
-  },
-  computed: {
-    textColor(): string {
-      if (this.timerCount > (this.duration / 3) * 2) {
-        return "#229954";
-      }
-      if (this.timerCount > this.duration / 3) {
-        return "#D4AC0D";
-      }
-      if (this.timerCount === 0) {
-        return "grey";
-      }
-      return "#CB4335";
-    },
-  },
-  watch: {
-    startTimestamp() {
-      this.resetTimer();
-      this.startInterval();
-    },
-    pauseTimer(newValue) {
-      if (newValue) {
-        clearInterval(this.intervalHandler);
-      }
-    },
-  },
-  created() {
-    this.timerCount = this.duration;
-    if (this.votingStarted) {
-      if (this.startTimestamp) {
-        this.startInterval();
+const COLOR_INACTIVE = "#808080";
+const COLOR_PLENTY = "#229954";
+const COLOR_WARNING = "#D4AC0D";
+const COLOR_URGENT = "#CB4335";
+
+const props = defineProps<{
+  startTimestamp: string;
+  duration: number;
+  pauseTimer: boolean;
+  votingStarted: boolean;
+}>();
+
+const emit = defineEmits<{ timerFinished: [] }>();
+
+const timerCount = ref(0);
+let intervalHandle = -1;
+let localStartTime = 0;
+let initialElapsed = 0;
+
+const textColor = computed(() => {
+  if (timerCount.value === 0) return COLOR_INACTIVE;
+  if (timerCount.value > (props.duration / 3) * 2) return COLOR_PLENTY;
+  if (timerCount.value > props.duration / 3) return COLOR_WARNING;
+  return COLOR_URGENT;
+});
+
+const formattedTime = computed(() => {
+  if (props.duration === 0) return "∞";
+  if (!props.startTimestamp) return "";
+  const minutes = Math.floor(timerCount.value / 60);
+  const seconds = (timerCount.value % 60).toString().padStart(2, "0");
+  return `${minutes}:${seconds}`;
+});
+
+function stopInterval() {
+  if (intervalHandle !== -1) {
+    clearInterval(intervalHandle);
+    intervalHandle = -1;
+  }
+}
+
+function startInterval() {
+  stopInterval();
+  if (props.duration === 0 || !props.startTimestamp) return;
+
+  const serverStartMs = new Date(props.startTimestamp).getTime();
+  if (Number.isNaN(serverStartMs)) return;
+
+  // Clamp initial offset to >= 0 so a client clock behind the server
+  // never produces a negative elapsed value
+  const now = Date.now();
+  initialElapsed = Math.max(0, (now - serverStartMs) / 1000);
+  localStartTime = now;
+
+  if (initialElapsed >= props.duration) {
+    timerCount.value = 0;
+    emit("timerFinished");
+    return;
+  }
+
+  timerCount.value = Math.min(props.duration, Math.ceil(props.duration - initialElapsed));
+
+  intervalHandle = window.setInterval(() => {
+    const localElapsed = (Date.now() - localStartTime) / 1000;
+    const totalElapsed = initialElapsed + localElapsed;
+    const remaining = props.duration - totalElapsed;
+
+    if (remaining <= 0) {
+      timerCount.value = 0;
+      emit("timerFinished");
+      stopInterval();
+    } else {
+      timerCount.value = Math.min(props.duration, Math.ceil(remaining));
+    }
+  }, 100);
+}
+
+watch(
+  () => props.startTimestamp,
+  () => {
+    stopInterval();
+    timerCount.value = props.duration;
+    startInterval();
+  }
+);
+
+watch(
+  () => props.duration,
+  (newDuration, oldDuration) => {
+    if (oldDuration === 0 && newDuration > 0) {
+      timerCount.value = newDuration;
+      if (props.votingStarted && props.startTimestamp && !props.pauseTimer) {
+        startInterval();
       }
     }
-  },
-  beforeUnmount() {
-    clearInterval(this.intervalHandler);
-  },
-  methods: {
-    formatTimer() {
-      if (this.duration === 0) {
-        return "∞";
-      }
-      if (this.startTimestamp === "") {
-        return "";
-      }
-      const minutes = Math.floor(this.timerCount / 60);
-      const seconds = (this.timerCount % 60).toString().padStart(2, "0");
-      return `${minutes}:${seconds}`;
-    },
-    resetTimer() {
-      this.timerCount = this.duration;
-    },
-    startInterval() {
-      clearInterval(this.intervalHandler);
-      if (this.duration === 0) {
-        return;
-      }
-      this.intervalHandler = window.setInterval(() => {
-        if (this.timerCount > 0) {
-          const startTime = new Date(this.startTimestamp).getTime();
-          const currentTime = new Date().getTime();
-          this.timerCount = Math.ceil(this.duration - (currentTime - startTime) / 1000);
-          if (this.timerCount > this.duration || this.timerCount < 0) {
-            clearInterval(this.intervalHandler);
-            this.localClockTimer();
-          }
-        } else {
-          this.$emit("timerFinished");
-          clearInterval(this.intervalHandler);
-        }
-      }, 100);
-    },
-    async localClockTimer() {
-      if (this.member !== "") {
-        const response = (
-          await axios.get(constants.backendURL + "/get-timer-value", {
-            params: {
-              memberID: this.member,
-            },
-          })
-        ).data;
-        this.timerCount = Math.ceil(this.duration - response / 1000);
-        this.intervalHandler = window.setInterval(() => {
-          if (this.timerCount > 0) {
-            this.timerCount = this.timerCount - 1;
-          } else {
-            this.$emit("timerFinished");
-            clearInterval(this.intervalHandler);
-          }
-        }, 1000);
-      }
-    },
-  },
-});
+  }
+);
+
+watch(
+  () => props.pauseTimer,
+  (paused) => {
+    if (paused) stopInterval();
+  }
+);
+
+timerCount.value = props.duration;
+if (props.votingStarted && props.startTimestamp) {
+  startInterval();
+}
+
+onBeforeUnmount(stopInterval);
 </script>
 
-<!-- Add "scoped" attribute to limit CSS/SCSS to this component only -->
 <style lang="scss" scoped>
 .estimate-timer {
   font-size: 1.5rem;
   font-weight: 700;
   border-radius: 0.5rem;
 }
+
 .card-body {
   padding: 0.5rem;
 }

--- a/frontend/src/components/EstimateTimer.vue
+++ b/frontend/src/components/EstimateTimer.vue
@@ -94,7 +94,9 @@ watch(
   () => {
     stopInterval();
     timerCount.value = props.duration;
-    startInterval();
+    if (!props.pauseTimer) {
+      startInterval();
+    }
   }
 );
 
@@ -116,12 +118,14 @@ watch(
     if (paused) {
       tick();
       stopInterval();
+    } else if (props.startTimestamp && props.duration > 0) {
+      startInterval();
     }
   }
 );
 
 timerCount.value = props.duration;
-if (props.votingStarted && props.startTimestamp) {
+if (props.votingStarted && props.startTimestamp && !props.pauseTimer) {
   startInterval();
 }
 

--- a/frontend/src/components/EstimateTimer.vue
+++ b/frontend/src/components/EstimateTimer.vue
@@ -182,6 +182,7 @@ watch(
       shouldEmitOnExpiry = false;
       if (!props.startTimestamp) timerCount.value = 0;
     } else if (props.startTimestamp && props.duration > 0 && !roundExpired) {
+      shouldEmitOnExpiry = true;
       startInterval();
     }
   }

--- a/frontend/src/components/EstimateTimer.vue
+++ b/frontend/src/components/EstimateTimer.vue
@@ -30,13 +30,20 @@ const props = withDefaults(
 const emit = defineEmits<{ timerFinished: [] }>();
 
 const timerCount = ref(0);
+
+// Non-reactive internal state
 let intervalHandle = -1;
 let localStartTime = 0;
 let initialElapsed = 0;
 let syncGeneration = 0;
+let roundExpired = false;
+let shouldEmitOnExpiry = false;
+let unmounted = false;
 
+// --- Computed ---
 const textColor = computed(() => {
   if (timerCount.value === 0) return COLOR_INACTIVE;
+  if (!props.startTimestamp && props.pauseTimer) return COLOR_INACTIVE;
   if (timerCount.value > (props.duration * 2) / 3) return COLOR_PLENTY;
   if (timerCount.value > props.duration / 3) return COLOR_WARNING;
   return COLOR_URGENT;
@@ -44,11 +51,16 @@ const textColor = computed(() => {
 
 const formattedTime = computed(() => {
   if (props.duration === 0) return "∞";
-  if (!props.startTimestamp) return "";
+  if (!props.startTimestamp) return props.pauseTimer ? "0:00" : "";
   const minutes = Math.floor(timerCount.value / 60);
   const seconds = (timerCount.value % 60).toString().padStart(2, "0");
   return `${minutes}:${seconds}`;
 });
+
+// --- Timer core ---
+function clampElapsed(seconds: number): number {
+  return Math.min(props.duration, Math.max(0, seconds));
+}
 
 function stopInterval() {
   if (intervalHandle !== -1) {
@@ -65,67 +77,80 @@ function tick(): boolean {
 
   if (remaining <= 0) {
     timerCount.value = 0;
+    roundExpired = true;
     return true;
   }
   timerCount.value = Math.min(props.duration, Math.ceil(remaining));
   return false;
 }
 
+function handleExpiry() {
+  if (shouldEmitOnExpiry) {
+    shouldEmitOnExpiry = false;
+    emit("timerFinished");
+  }
+}
+
 function beginInterval() {
   if (tick()) {
-    emit("timerFinished");
+    handleExpiry();
     return;
   }
   intervalHandle = window.setInterval(() => {
     if (tick()) {
-      emit("timerFinished");
       stopInterval();
+      handleExpiry();
     }
   }, 100);
 }
 
-async function startInterval(resumeFromCurrent = false) {
+// --- Server sync ---
+async function fetchServerElapsed(gen: number, rawElapsed: number): Promise<number | null> {
+  try {
+    const response = await axios.get(constants.backendURL + "/get-timer-value", {
+      params: { memberID: props.member },
+    });
+    if (gen !== syncGeneration || unmounted) return null;
+    const elapsed = Number(response.data);
+    return Number.isFinite(elapsed) ? elapsed / 1000 : rawElapsed;
+  } catch {
+    if (gen !== syncGeneration || unmounted) return null;
+    return rawElapsed;
+  }
+}
+
+async function startInterval() {
   stopInterval();
+  localStartTime = 0;
   if (props.duration === 0 || !props.startTimestamp) return;
 
   const gen = ++syncGeneration;
-
-  if (resumeFromCurrent) {
-    initialElapsed = props.duration - timerCount.value;
-    localStartTime = Date.now();
-    beginInterval();
-    return;
-  }
-
   const serverStartMs = new Date(props.startTimestamp).getTime();
   if (Number.isNaN(serverStartMs)) return;
 
-  const now = Date.now();
-  const rawElapsed = (now - serverStartMs) / 1000;
+  const rawElapsed = (Date.now() - serverStartMs) / 1000;
+  const hasClockSkew = rawElapsed < 0 || rawElapsed > props.duration;
 
-  // Clock skew detected: Use backend endpoint to get the true server-side elapsed time for members
-  if ((rawElapsed < 0 || rawElapsed > props.duration) && props.member) {
-    try {
-      const response = await axios.get(constants.backendURL + "/get-timer-value", {
-        params: { memberID: props.member },
-      });
-      if (gen !== syncGeneration) return;
-      initialElapsed = Math.max(0, response.data / 1000);
-    } catch {
-      if (gen !== syncGeneration) return;
-      initialElapsed = Math.max(0, rawElapsed);
-    }
+  if (hasClockSkew && props.member) {
+    const serverElapsed = await fetchServerElapsed(gen, rawElapsed);
+    if (serverElapsed === null) return;
+    initialElapsed = clampElapsed(serverElapsed);
   } else {
-    initialElapsed = Math.max(0, rawElapsed);
+    initialElapsed = clampElapsed(rawElapsed);
   }
+
+  if (props.pauseTimer) return;
 
   localStartTime = Date.now();
   beginInterval();
 }
 
+// --- Watchers ---
 watch(
   () => props.startTimestamp,
   () => {
+    roundExpired = false;
+    shouldEmitOnExpiry = true;
     stopInterval();
     timerCount.value = props.duration;
     if (!props.pauseTimer) {
@@ -138,8 +163,10 @@ watch(
   () => props.duration,
   (newDuration, oldDuration) => {
     if (oldDuration === 0 && newDuration > 0) {
+      roundExpired = false;
       timerCount.value = newDuration;
       if (props.votingStarted && props.startTimestamp && !props.pauseTimer) {
+        shouldEmitOnExpiry = true;
         startInterval();
       }
     }
@@ -150,20 +177,27 @@ watch(
   () => props.pauseTimer,
   (paused) => {
     if (paused) {
-      tick();
+      if (tick()) handleExpiry();
       stopInterval();
-    } else if (props.startTimestamp && props.duration > 0) {
-      startInterval(true);
+      shouldEmitOnExpiry = false;
+      if (!props.startTimestamp) timerCount.value = 0;
+    } else if (props.startTimestamp && props.duration > 0 && !roundExpired) {
+      startInterval();
     }
   }
 );
 
-timerCount.value = props.duration;
+// --- Initialization ---
+timerCount.value = props.pauseTimer && !props.startTimestamp ? 0 : props.duration;
 if (props.votingStarted && props.startTimestamp && !props.pauseTimer) {
+  shouldEmitOnExpiry = true;
   startInterval();
 }
 
-onBeforeUnmount(stopInterval);
+onBeforeUnmount(() => {
+  unmounted = true;
+  stopInterval();
+});
 </script>
 
 <style lang="scss" scoped>

--- a/frontend/src/components/EstimateTimer.vue
+++ b/frontend/src/components/EstimateTimer.vue
@@ -1,6 +1,6 @@
 <template>
   <div class="d-flex justify-content-end estimate-timer">
-    <b-card-text :style="`color: ${textColor}`" class="timer">
+    <b-card-text :style="{ color: textColor }" class="timer">
       {{ formattedTime }}
     </b-card-text>
   </div>
@@ -30,7 +30,7 @@ let initialElapsed = 0;
 
 const textColor = computed(() => {
   if (timerCount.value === 0) return COLOR_INACTIVE;
-  if (timerCount.value > (props.duration / 3) * 2) return COLOR_PLENTY;
+  if (timerCount.value > (props.duration * 2) / 3) return COLOR_PLENTY;
   if (timerCount.value > props.duration / 3) return COLOR_WARNING;
   return COLOR_URGENT;
 });
@@ -50,6 +50,20 @@ function stopInterval() {
   }
 }
 
+function tick(): boolean {
+  if (localStartTime === 0) return false;
+
+  const localElapsed = (Date.now() - localStartTime) / 1000;
+  const remaining = props.duration - initialElapsed - localElapsed;
+
+  if (remaining <= 0) {
+    timerCount.value = 0;
+    return true;
+  }
+  timerCount.value = Math.min(props.duration, Math.ceil(remaining));
+  return false;
+}
+
 function startInterval() {
   stopInterval();
   if (props.duration === 0 || !props.startTimestamp) return;
@@ -57,31 +71,20 @@ function startInterval() {
   const serverStartMs = new Date(props.startTimestamp).getTime();
   if (Number.isNaN(serverStartMs)) return;
 
-  // Clamp initial offset to >= 0 so a client clock behind the server
-  // never produces a negative elapsed value
+  // Clamp to >= 0 so a client clock behind the server never goes negative
   const now = Date.now();
   initialElapsed = Math.max(0, (now - serverStartMs) / 1000);
   localStartTime = now;
 
-  if (initialElapsed >= props.duration) {
-    timerCount.value = 0;
+  if (tick()) {
     emit("timerFinished");
     return;
   }
 
-  timerCount.value = Math.min(props.duration, Math.ceil(props.duration - initialElapsed));
-
   intervalHandle = window.setInterval(() => {
-    const localElapsed = (Date.now() - localStartTime) / 1000;
-    const totalElapsed = initialElapsed + localElapsed;
-    const remaining = props.duration - totalElapsed;
-
-    if (remaining <= 0) {
-      timerCount.value = 0;
+    if (tick()) {
       emit("timerFinished");
       stopInterval();
-    } else {
-      timerCount.value = Math.min(props.duration, Math.ceil(remaining));
     }
   }, 100);
 }
@@ -110,7 +113,10 @@ watch(
 watch(
   () => props.pauseTimer,
   (paused) => {
-    if (paused) stopInterval();
+    if (paused) {
+      tick();
+      stopInterval();
+    }
   }
 );
 
@@ -127,10 +133,6 @@ onBeforeUnmount(stopInterval);
   font-size: 1.5rem;
   font-weight: 700;
   border-radius: 0.5rem;
-}
-
-.card-body {
-  padding: 0.5rem;
 }
 
 .card-text {

--- a/frontend/src/components/EstimateTimer.vue
+++ b/frontend/src/components/EstimateTimer.vue
@@ -11,6 +11,7 @@ import { ref, computed, watch, onBeforeUnmount } from "vue";
 import axios from "axios";
 import constants from "@/constants";
 
+const TICK_INTERVAL_MS = 100;
 const COLOR_INACTIVE = "#808080";
 const COLOR_PLENTY = "#229954";
 const COLOR_WARNING = "#D4AC0D";
@@ -29,13 +30,13 @@ const props = withDefaults(
 
 const emit = defineEmits<{ timerFinished: [] }>();
 
+// --- State ---
 const timerCount = ref(0);
 
-// Non-reactive internal state
-let intervalHandle = -1;
-let localStartTime = 0;
-let initialElapsed = 0;
-let syncGeneration = 0;
+let tickHandle = -1;
+let tickOrigin = 0;
+let elapsedBeforeTick = 0;
+let asyncGeneration = 0;
 let roundExpired = false;
 let shouldEmitOnExpiry = false;
 let unmounted = false;
@@ -62,18 +63,19 @@ function clampElapsed(seconds: number): number {
   return Math.min(props.duration, Math.max(0, seconds));
 }
 
-function stopInterval() {
-  if (intervalHandle !== -1) {
-    clearInterval(intervalHandle);
-    intervalHandle = -1;
+function stopTicking() {
+  if (tickHandle !== -1) {
+    clearInterval(tickHandle);
+    tickHandle = -1;
   }
 }
 
+// Returns true when the timer has expired
 function tick(): boolean {
-  if (localStartTime === 0) return false;
+  if (tickOrigin === 0) return false;
 
-  const localElapsed = (Date.now() - localStartTime) / 1000;
-  const remaining = props.duration - initialElapsed - localElapsed;
+  const tickElapsed = (Date.now() - tickOrigin) / 1000;
+  const remaining = props.duration - elapsedBeforeTick - tickElapsed;
 
   if (remaining <= 0) {
     timerCount.value = 0;
@@ -84,47 +86,47 @@ function tick(): boolean {
   return false;
 }
 
-function handleExpiry() {
+function onExpired() {
   if (shouldEmitOnExpiry) {
     shouldEmitOnExpiry = false;
     emit("timerFinished");
   }
 }
 
-function beginInterval() {
+function startTicking() {
   if (tick()) {
-    handleExpiry();
+    onExpired();
     return;
   }
-  intervalHandle = window.setInterval(() => {
+  tickHandle = window.setInterval(() => {
     if (tick()) {
-      stopInterval();
-      handleExpiry();
+      stopTicking();
+      onExpired();
     }
-  }, 100);
+  }, TICK_INTERVAL_MS);
 }
 
-// --- Server sync ---
-async function fetchServerElapsed(gen: number, rawElapsed: number): Promise<number | null> {
+// --- Timer sync ---
+async function fetchServerElapsed(gen: number, fallback: number): Promise<number | null> {
   try {
     const response = await axios.get(constants.backendURL + "/get-timer-value", {
       params: { memberID: props.member },
     });
-    if (gen !== syncGeneration || unmounted) return null;
+    if (gen !== asyncGeneration || unmounted) return null;
     const elapsed = Number(response.data);
-    return Number.isFinite(elapsed) ? elapsed / 1000 : rawElapsed;
+    return Number.isFinite(elapsed) ? elapsed / 1000 : fallback;
   } catch {
-    if (gen !== syncGeneration || unmounted) return null;
-    return rawElapsed;
+    if (gen !== asyncGeneration || unmounted) return null;
+    return fallback;
   }
 }
 
-async function startInterval() {
-  stopInterval();
-  localStartTime = 0;
+async function syncTimer() {
+  stopTicking();
+  tickOrigin = 0;
   if (props.duration === 0 || !props.startTimestamp) return;
 
-  const gen = ++syncGeneration;
+  const gen = ++asyncGeneration;
   const serverStartMs = new Date(props.startTimestamp).getTime();
   if (Number.isNaN(serverStartMs)) return;
 
@@ -134,15 +136,25 @@ async function startInterval() {
   if (hasClockSkew && props.member) {
     const serverElapsed = await fetchServerElapsed(gen, rawElapsed);
     if (serverElapsed === null) return;
-    initialElapsed = clampElapsed(serverElapsed);
+    elapsedBeforeTick = clampElapsed(serverElapsed);
   } else {
-    initialElapsed = clampElapsed(rawElapsed);
+    elapsedBeforeTick = clampElapsed(rawElapsed);
   }
+
+  // Sync display to actual remaining time (even when paused)
+  const remaining = props.duration - elapsedBeforeTick;
+  if (remaining <= 0) {
+    timerCount.value = 0;
+    roundExpired = true;
+    onExpired();
+    return;
+  }
+  timerCount.value = Math.ceil(remaining);
 
   if (props.pauseTimer) return;
 
-  localStartTime = Date.now();
-  beginInterval();
+  tickOrigin = Date.now();
+  startTicking();
 }
 
 // --- Watchers ---
@@ -150,12 +162,12 @@ watch(
   () => props.startTimestamp,
   () => {
     roundExpired = false;
-    shouldEmitOnExpiry = true;
-    stopInterval();
+    stopTicking();
     timerCount.value = props.duration;
     if (!props.pauseTimer) {
-      startInterval();
+      shouldEmitOnExpiry = true;
     }
+    syncTimer();
   }
 );
 
@@ -165,9 +177,11 @@ watch(
     if (oldDuration === 0 && newDuration > 0) {
       roundExpired = false;
       timerCount.value = newDuration;
-      if (props.votingStarted && props.startTimestamp && !props.pauseTimer) {
-        shouldEmitOnExpiry = true;
-        startInterval();
+      if (props.votingStarted && props.startTimestamp) {
+        if (!props.pauseTimer) {
+          shouldEmitOnExpiry = true;
+        }
+        syncTimer();
       }
     }
   }
@@ -177,27 +191,29 @@ watch(
   () => props.pauseTimer,
   (paused) => {
     if (paused) {
-      if (tick()) handleExpiry();
-      stopInterval();
+      if (tick()) onExpired();
+      stopTicking();
       shouldEmitOnExpiry = false;
       if (!props.startTimestamp) timerCount.value = 0;
     } else if (props.startTimestamp && props.duration > 0 && !roundExpired) {
       shouldEmitOnExpiry = true;
-      startInterval();
+      syncTimer();
     }
   }
 );
 
 // --- Initialization ---
 timerCount.value = props.pauseTimer && !props.startTimestamp ? 0 : props.duration;
-if (props.votingStarted && props.startTimestamp && !props.pauseTimer) {
-  shouldEmitOnExpiry = true;
-  startInterval();
+if (props.votingStarted && props.startTimestamp) {
+  if (!props.pauseTimer) {
+    shouldEmitOnExpiry = true;
+  }
+  syncTimer();
 }
 
 onBeforeUnmount(() => {
   unmounted = true;
-  stopInterval();
+  stopTicking();
 });
 </script>
 

--- a/frontend/src/components/EstimateTimer.vue
+++ b/frontend/src/components/EstimateTimer.vue
@@ -8,18 +8,24 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount } from "vue";
+import axios from "axios";
+import constants from "@/constants";
 
 const COLOR_INACTIVE = "#808080";
 const COLOR_PLENTY = "#229954";
 const COLOR_WARNING = "#D4AC0D";
 const COLOR_URGENT = "#CB4335";
 
-const props = defineProps<{
-  startTimestamp: string;
-  duration: number;
-  pauseTimer: boolean;
-  votingStarted: boolean;
-}>();
+const props = withDefaults(
+  defineProps<{
+    startTimestamp: string;
+    duration: number;
+    pauseTimer: boolean;
+    member?: string;
+    votingStarted: boolean;
+  }>(),
+  { member: "" }
+);
 
 const emit = defineEmits<{ timerFinished: [] }>();
 
@@ -27,6 +33,7 @@ const timerCount = ref(0);
 let intervalHandle = -1;
 let localStartTime = 0;
 let initialElapsed = 0;
+let syncGeneration = 0;
 
 const textColor = computed(() => {
   if (timerCount.value === 0) return COLOR_INACTIVE;
@@ -64,29 +71,56 @@ function tick(): boolean {
   return false;
 }
 
-function startInterval() {
-  stopInterval();
-  if (props.duration === 0 || !props.startTimestamp) return;
-
-  const serverStartMs = new Date(props.startTimestamp).getTime();
-  if (Number.isNaN(serverStartMs)) return;
-
-  // Clamp to >= 0 so a client clock behind the server never goes negative
-  const now = Date.now();
-  initialElapsed = Math.max(0, (now - serverStartMs) / 1000);
-  localStartTime = now;
-
+function beginInterval() {
   if (tick()) {
     emit("timerFinished");
     return;
   }
-
   intervalHandle = window.setInterval(() => {
     if (tick()) {
       emit("timerFinished");
       stopInterval();
     }
   }, 100);
+}
+
+async function startInterval(resumeFromCurrent = false) {
+  stopInterval();
+  if (props.duration === 0 || !props.startTimestamp) return;
+
+  const gen = ++syncGeneration;
+
+  if (resumeFromCurrent) {
+    initialElapsed = props.duration - timerCount.value;
+    localStartTime = Date.now();
+    beginInterval();
+    return;
+  }
+
+  const serverStartMs = new Date(props.startTimestamp).getTime();
+  if (Number.isNaN(serverStartMs)) return;
+
+  const now = Date.now();
+  const rawElapsed = (now - serverStartMs) / 1000;
+
+  // Clock skew detected: Use backend endpoint to get the true server-side elapsed time for members
+  if ((rawElapsed < 0 || rawElapsed > props.duration) && props.member) {
+    try {
+      const response = await axios.get(constants.backendURL + "/get-timer-value", {
+        params: { memberID: props.member },
+      });
+      if (gen !== syncGeneration) return;
+      initialElapsed = Math.max(0, response.data / 1000);
+    } catch {
+      if (gen !== syncGeneration) return;
+      initialElapsed = Math.max(0, rawElapsed);
+    }
+  } else {
+    initialElapsed = Math.max(0, rawElapsed);
+  }
+
+  localStartTime = Date.now();
+  beginInterval();
 }
 
 watch(
@@ -119,7 +153,7 @@ watch(
       tick();
       stopInterval();
     } else if (props.startTimestamp && props.duration > 0) {
-      startInterval();
+      startInterval(true);
     }
   }
 );

--- a/frontend/src/store/index.ts
+++ b/frontend/src/store/index.ts
@@ -116,6 +116,7 @@ export const useDiveniStore = defineStore("diveni-store", {
       this.userStories = [];
       this.memberUpdates = [];
       this.notifications = [];
+      this.timerTimestamp = undefined;
       this.webSocketConnected = false;
       this.stompClient = undefined;
     },
@@ -123,6 +124,7 @@ export const useDiveniStore = defineStore("diveni-store", {
       this.members = [];
       this.memberUpdates = [];
       this.notifications = [];
+      this.timerTimestamp = undefined;
       this.webSocketConnected = false;
       this.stompClient = undefined;
     },

--- a/frontend/src/views/MemberVotePage.vue
+++ b/frontend/src/views/MemberVotePage.vue
@@ -19,7 +19,6 @@
             :start-timestamp="timerTimestamp"
             :pause-timer="estimateFinished || pauseSession"
             :duration="timerCountdownNumber"
-            :member="memberID"
             :voting-started="isStartVoting"
           />
         </b-col>
@@ -37,7 +36,6 @@
             :start-timestamp="timerTimestamp"
             :pause-timer="estimateFinished || pauseSession"
             :duration="timerCountdownNumber"
-            :member="memberID"
             :voting-started="isStartVoting"
           />
         </b-col>

--- a/frontend/src/views/MemberVotePage.vue
+++ b/frontend/src/views/MemberVotePage.vue
@@ -19,6 +19,7 @@
             :start-timestamp="timerTimestamp"
             :pause-timer="estimateFinished || pauseSession"
             :duration="timerCountdownNumber"
+            :member="memberID"
             :voting-started="isStartVoting"
           />
         </b-col>
@@ -36,6 +37,7 @@
             :start-timestamp="timerTimestamp"
             :pause-timer="estimateFinished || pauseSession"
             :duration="timerCountdownNumber"
+            :member="memberID"
             :voting-started="isStartVoting"
           />
         </b-col>

--- a/frontend/src/views/SessionPage.vue
+++ b/frontend/src/views/SessionPage.vue
@@ -481,10 +481,10 @@ export default defineComponent({
       if (isConnected) {
         console.debug("SessionPage: member connected to websocket");
         setTimeout(() => {
-          this.registerAdminPrincipalOnBackend();
           this.subscribeWSMemberUpdated();
           this.subscribeOnTimerStart();
           this.subscribeWSNotification();
+          this.registerAdminPrincipalOnBackend();
           if (this.startNewSessionOnMountedString === "true") {
             this.sendRestartMessage();
           }


### PR DESCRIPTION
 ## Summary
  - Fix timer showing more than configured duration and freezing (clock drift + Math.ceil)
  - Fix members seeing "0:01" instead of "0:00" when timer expires (final tick before pause)
  - While we were at it, migrated the EstimateTimer.vue directly to the new Vue 3 composition API