### PR TITLE
fix: P1 high-priority fixes (connection pooling, optimistic locking, GPT upgrade, Springdoc, controller split)

### DIFF
--- a/ai/service/gpt_service.py
+++ b/ai/service/gpt_service.py
@@ -10,7 +10,7 @@ import json
 
 def setUp():
     API_KEY = os.environ.get('api_key')
-    model_id = 'gpt-3.5-turbo-instruct'
+    model_id = 'gpt-4o-mini'
     client = OpenAI(api_key=API_KEY)
     return client, model_id
 
@@ -66,19 +66,24 @@ def get_prompt(information):
     return prompt
 
 
+def _chat_completion(client, model_id, prompt, max_tokens=100, temperature=0.8):
+    """Helper to call OpenAI chat completions API."""
+    messages = [{"role": "user", "content": prompt}]
+    completion = client.chat.completions.create(
+        model=model_id,
+        messages=messages,
+        max_tokens=max_tokens,
+        temperature=temperature
+    )
+    return completion.choices[0].message.content.strip()
+
+
 async def improve_title(original_title: str, confidential_data: dict):
     print("gpt_service: --> improve_title()")
     swapped_data, new_title = replace_confidential_data(original_title, confidential_data)
     client, model_id = setUp()
-    # "Improve the title of this issue: "
     prompt_input = get_prompt("title") + new_title + "\nAnswer:"
-    completion = client.completions.create(
-        model=model_id,
-        prompt=prompt_input,
-        max_tokens=100,
-        temperature=0.8
-    )
-    response = completion.choices[0].text.lstrip().rstrip()
+    response = _chat_completion(client, model_id, prompt_input, max_tokens=100, temperature=0.8)
     title = replace_confidential_data_to_original(response, swapped_data)
     print("gpt_service: <-- improve_title()")
     return title
@@ -88,26 +93,17 @@ async def improve_description(original_user_story: UserStory):
     print("gpt_service: --> improve_description()")
     swappedData, new_description = replace_confidential_data(original_user_story.description, original_user_story.confidential_data)
     client, model_id = setUp()
-    # prompt_input = ("Send JSON with 'description' & 'acceptance_criteria' (acceptance_criteria should be a list & description needs "
-    #                "improvement) for this user story description: ") + new_description
 
     if original_user_story.language == "english":
         final_prompt = get_prompt("improve_description") + new_description + "\n Solution: "
     else:
         final_prompt = get_prompt("improve_description_german") + new_description + "\n Antwort: "
 
-    completion = client.completions.create(
-        model=model_id,
-        prompt=final_prompt,
-        max_tokens=1500,
-        temperature=0.1
-    )
-    output = completion.choices[0].text
+    output = _chat_completion(client, model_id, final_prompt, max_tokens=1500, temperature=0.1)
     start_brace = output.find('{')
     end_brace = output.rfind('}')
     json_ready_string = output[start_brace: end_brace + 1]
     data = json.loads(json_ready_string)
-    # data = json.loads(completion.choices[0].text.strip("'<>() ").replace('\'', '\"'), strict = False)
     description = data.get("description", "")
     acceptance_criteria = data.get("acceptance_criteria", [])
     if original_user_story.language == "german":
@@ -125,17 +121,8 @@ async def grammar_check(original_user_story: UserStory):
     print("gpt_service: --> grammar_check()")
     swappedData, new_description = replace_confidential_data(original_user_story.description, original_user_story.confidential_data)
     client, model_id = setUp()
-    prompt_input = ("Fix grammar & syntax mistakes, but do not add new elements. Send it back as a JSON with 'description' and "
-                    "'acceptance_criteria' (list) field."
-                    "If the text does not mention acceptance criteria, leave the field blank. This is the text: ") + new_description
     final_prompt = get_prompt("grammar_check") + new_description + "\n Solution: "
-    completion = client.completions.create(
-        model=model_id,
-        prompt=final_prompt,
-        max_tokens=1500,
-        temperature=0
-    )
-    output = completion.choices[0].text
+    output = _chat_completion(client, model_id, final_prompt, max_tokens=1500, temperature=0)
     start_brace = output.find('{')
     end_brace = output.rfind('}')
     json_ready_string = output[start_brace: end_brace + 1]
@@ -176,15 +163,9 @@ async def estimate_user_story(original_data: Estimation_data):
             original_data.voteSet)
     else:
         prompt = ("Task: Send a JSON with \"estimation\" and estimate the effort for this user story: Title: " + new_title + "\n "
-                                                                                                                             "Description: " + new_description + "\n Valid Options are: " + str(
+                                                                                                                              "Description: " + new_description + "\n Valid Options are: " + str(
             original_data.voteSet))
-    completion = client.completions.create(
-        model=model_id,
-        prompt=prompt,
-        max_tokens=1000,
-        temperature=0
-    )
-    output = completion.choices[0].text
+    output = _chat_completion(client, model_id, prompt, max_tokens=1000, temperature=0)
     start_brace = output.find('{')
     end_brace = output.rfind('}')
     json_ready_string = output[start_brace: end_brace + 1]
@@ -203,13 +184,7 @@ async def split_user_story(data: UserStory):
         prompt = get_prompt("split_story") + new_title + "\nDescription: " + new_description + "\nSolution:"
     else:
         prompt = get_prompt("split_story_german") + new_title + "\nBeschreibung: " + new_description + "\nAntwort:"
-    completion = client.completions.create(
-        model=model_id,
-        prompt=prompt,
-        max_tokens=3000,
-        temperature=0
-    )
-    output = completion.choices[0].text
+    output = _chat_completion(client, model_id, prompt, max_tokens=3000, temperature=0)
     start_brace = output.find('{')
     end_brace = output.rfind('}')
     json_ready_string = output[start_brace: end_brace + 1]
@@ -231,6 +206,7 @@ async def split_user_story(data: UserStory):
     print("gpt_service: <-- split_user_story()")
     return user_story_list
 
+
 async def mark_description(data: UserStory):
     print("gpt_service: --> mark_description()")
     client, model_id = setUp()
@@ -239,13 +215,7 @@ async def mark_description(data: UserStory):
         prompt = get_prompt("mark_description") + new_description + "\nSolution:"
     else:
         prompt = get_prompt("mark_description_german") + new_description + "\nAntwort:"
-    completion = client.completions.create(
-        model=model_id,
-        prompt=prompt,
-        max_tokens=3000,
-        temperature=0
-    )
-    output = completion.choices[0].text
+    output = _chat_completion(client, model_id, prompt, max_tokens=3000, temperature=0)
     start_brace = output.find('{')
     end_brace = output.rfind('}')
     json_ready_string = output[start_brace: end_brace + 1]
@@ -261,4 +231,3 @@ def check_api_key():
     api_key = os.environ.get('api_key')
     print("gpt_service: <-- check_api_key()")
     return False if api_key is None else True
-

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -27,8 +27,7 @@ dependencies {
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.17'
     implementation 'com.google.api-client:google-api-client-gson:1.35.2'
     implementation 'com.google.code.gson:gson:2.14.0'
-    implementation 'org.springdoc:springdoc-openapi-ui:1.8.0'
-    implementation 'org.apache.httpcomponents:httpclient:4.5.14'
+    implementation 'org.apache.httpcomponents.client5:httpclient5:5.4.3'
     implementation 'org.json:json:20230227'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 

--- a/backend/src/main/java/io/diveni/backend/config/RestTemplateConfig.java
+++ b/backend/src/main/java/io/diveni/backend/config/RestTemplateConfig.java
@@ -3,12 +3,13 @@ package io.diveni.backend.config;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
+import org.apache.hc.core5.util.TimeValue;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.concurrent.TimeUnit;
+import java.time.Duration;
 
 @Configuration
 public class RestTemplateConfig {
@@ -22,13 +23,13 @@ public class RestTemplateConfig {
     CloseableHttpClient httpClient =
         HttpClientBuilder.create()
             .setConnectionManager(connectionManager)
-            .evictIdleConnections(30, TimeUnit.SECONDS)
+            .evictIdleConnections(TimeValue.ofSeconds(30))
             .build();
 
     HttpComponentsClientHttpRequestFactory factory =
         new HttpComponentsClientHttpRequestFactory(httpClient);
-    factory.setConnectTimeout(5_000);
-    factory.setReadTimeout(10_000);
+    factory.setConnectTimeout(Duration.ofSeconds(5));
+    factory.setReadTimeout(Duration.ofSeconds(10));
 
     return new RestTemplate(factory);
   }

--- a/backend/src/main/java/io/diveni/backend/config/RestTemplateConfig.java
+++ b/backend/src/main/java/io/diveni/backend/config/RestTemplateConfig.java
@@ -1,3 +1,8 @@
+/*
+  SPDX-License-Identifier: AGPL-3.0-or-later
+  Diveni - The Planing-Poker App
+  Copyright (C) 2022 Diveni Team, AUME-Team 21/22, HTWG Konstanz
+*/
 package io.diveni.backend.config;
 
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;

--- a/backend/src/main/java/io/diveni/backend/config/RestTemplateConfig.java
+++ b/backend/src/main/java/io/diveni/backend/config/RestTemplateConfig.java
@@ -1,15 +1,35 @@
 package io.diveni.backend.config;
 
-import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManager;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.HttpComponentsClientHttpRequestFactory;
 import org.springframework.web.client.RestTemplate;
+
+import java.util.concurrent.TimeUnit;
 
 @Configuration
 public class RestTemplateConfig {
 
   @Bean
-  public RestTemplate restTemplate(RestTemplateBuilder builder) {
-    return builder.build();
+  public RestTemplate restTemplate() {
+    PoolingHttpClientConnectionManager connectionManager = new PoolingHttpClientConnectionManager();
+    connectionManager.setMaxTotal(200);
+    connectionManager.setDefaultMaxPerRoute(20);
+
+    CloseableHttpClient httpClient =
+        HttpClientBuilder.create()
+            .setConnectionManager(connectionManager)
+            .evictIdleConnections(30, TimeUnit.SECONDS)
+            .build();
+
+    HttpComponentsClientHttpRequestFactory factory =
+        new HttpComponentsClientHttpRequestFactory(httpClient);
+    factory.setConnectTimeout(5_000);
+    factory.setReadTimeout(10_000);
+
+    return new RestTemplate(factory);
   }
 }

--- a/backend/src/main/java/io/diveni/backend/controller/RoutesController.java
+++ b/backend/src/main/java/io/diveni/backend/controller/RoutesController.java
@@ -5,8 +5,10 @@
 */
 package io.diveni.backend.controller;
 
+import java.text.ParseException;
 import java.time.LocalDate;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -129,6 +131,18 @@ public class RoutesController {
     Session session = ControllerUtils.getSessionOrThrowResponse(databaseService, sessionID);
     LOGGER.debug("<-- getSession()");
     return session;
+  }
+
+  @GetMapping("/get-timer-value")
+  public synchronized ResponseEntity<Long> getTimeValue(String memberID) throws ParseException {
+    LOGGER.debug("--> get-timer-value()");
+    Session session =
+        ControllerUtils.getSessionByMemberIDOrThrowResponse(databaseService, memberID);
+    Date startDate = Utils.getDateFromString(session.getTimerTimestamp());
+    Date currentDate = new Date();
+    long timeDifference = currentDate.getTime() - startDate.getTime();
+    LOGGER.debug("<-- get-timer-value() + " + timeDifference);
+    return new ResponseEntity<>(timeDifference, HttpStatus.OK);
   }
 
   private synchronized Session addMemberToSession(

--- a/backend/src/main/java/io/diveni/backend/controller/WebsocketController.java
+++ b/backend/src/main/java/io/diveni/backend/controller/WebsocketController.java
@@ -23,13 +23,9 @@ import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.ResponseEntity;
 import org.springframework.messaging.handler.annotation.MessageMapping;
 import org.springframework.messaging.handler.annotation.Payload;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.GetMapping;
-import java.text.ParseException;
 
 import io.diveni.backend.principals.AdminPrincipal;
 import io.diveni.backend.principals.MemberPrincipal;
@@ -280,18 +276,6 @@ public class WebsocketController {
         ControllerUtils.getSessionOrThrowResponse(databaseService, principal.getSessionID());
     webSocketService.sendSelectedUserStoryToMembers(session, index);
     LOGGER.debug("<-- adminSelectedUserStory()");
-  }
-
-  @GetMapping("/get-timer-value")
-  public synchronized ResponseEntity<Long> getTimeValue(String memberID) throws ParseException {
-    LOGGER.debug("--> get-timer-value()");
-    Session session =
-        ControllerUtils.getSessionByMemberIDOrThrowResponse(databaseService, memberID);
-    Date startDate = Utils.getDateFromString(session.getTimerTimestamp());
-    Date currentDate = new Date();
-    long timeDifference = currentDate.getTime() - startDate.getTime();
-    LOGGER.debug("<-- get-timer-value() + " + timeDifference);
-    return new ResponseEntity<>(timeDifference, HttpStatus.OK);
   }
 
   public boolean isMemberInSession(Principal principal) {

--- a/backend/src/main/java/io/diveni/backend/model/Session.java
+++ b/backend/src/main/java/io/diveni/backend/model/Session.java
@@ -24,15 +24,17 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.mongodb.core.mapping.Document;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
 import lombok.val;
 import org.bson.types.ObjectId;
 
 @Getter
-@RequiredArgsConstructor
+@AllArgsConstructor
 @EqualsAndHashCode
+@Builder(toBuilder = true)
 @Document("sessions")
 public class Session {
 

--- a/backend/src/main/java/io/diveni/backend/model/Session.java
+++ b/backend/src/main/java/io/diveni/backend/model/Session.java
@@ -75,6 +75,7 @@ public class Session {
 
   @Version
   @Setter
+  @EqualsAndHashCode.Exclude
   @JsonProperty(access = JsonProperty.Access.READ_ONLY)
   private Integer version;
 

--- a/backend/src/main/java/io/diveni/backend/model/Session.java
+++ b/backend/src/main/java/io/diveni/backend/model/Session.java
@@ -25,7 +25,6 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Version;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -36,7 +35,6 @@ import org.bson.types.ObjectId;
 @Getter
 @RequiredArgsConstructor
 @EqualsAndHashCode
-@Builder(toBuilder = true)
 @Document("sessions")
 public class Session {
 

--- a/backend/src/main/java/io/diveni/backend/model/Session.java
+++ b/backend/src/main/java/io/diveni/backend/model/Session.java
@@ -22,17 +22,19 @@ import java.util.stream.Stream;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.Version;
 import org.springframework.data.mongodb.core.mapping.Document;
 
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.val;
 import org.bson.types.ObjectId;
 
 @Getter
-@AllArgsConstructor
+@RequiredArgsConstructor
 @EqualsAndHashCode
 @Builder(toBuilder = true)
 @Document("sessions")
@@ -72,6 +74,11 @@ public class Session {
   private final boolean hostVoting;
 
   private final AdminVote hostEstimation;
+
+  @Version
+  @Setter
+  @JsonProperty(access = JsonProperty.Access.READ_ONLY)
+  private Integer version;
 
   static Comparator<String> estimationByIndex(List<String> set) {
     return Comparator.comparingInt((str) -> set.indexOf(str));

--- a/backend/src/main/java/io/diveni/backend/service/DatabaseService.java
+++ b/backend/src/main/java/io/diveni/backend/service/DatabaseService.java
@@ -78,6 +78,12 @@ public class DatabaseService {
         getOrCreateStatistic()
             .addOverallSessions(1)
             .addOverallAttendees(session.getMembers().size()));
+    // Restore version if lost during immutable copy, otherwise @Version may reject the delete
+    if (session.getVersion() == null && session.getDatabaseID() != null) {
+      sessionRepo
+          .findById(session.getDatabaseID().toHexString())
+          .ifPresent(current -> session.setVersion(current.getVersion()));
+    }
     sessionRepo.delete(session);
     LOGGER.debug("<-- deleteSession()");
   }

--- a/backend/src/main/java/io/diveni/backend/service/DatabaseService.java
+++ b/backend/src/main/java/io/diveni/backend/service/DatabaseService.java
@@ -60,13 +60,15 @@ public class DatabaseService {
 
   public Session saveSession(Session session) {
     LOGGER.debug("saveSession()");
-    if (session.getVersion() == null && session.getDatabaseID() != null) {
+    // setLastModified creates an immutable copy — version must be restored after
+    Session toSave = session.setLastModified(new Date());
+    if (toSave.getVersion() == null && toSave.getDatabaseID() != null) {
       // Version was lost during immutable copy — restore from DB for optimistic locking
       sessionRepo
-          .findById(session.getDatabaseID().toHexString())
-          .ifPresent(current -> session.setVersion(current.getVersion()));
+          .findById(toSave.getDatabaseID().toHexString())
+          .ifPresent(current -> toSave.setVersion(current.getVersion()));
     }
-    return sessionRepo.save(session.setLastModified(new Date()));
+    return sessionRepo.save(toSave);
   }
 
   @Transactional

--- a/backend/src/main/java/io/diveni/backend/service/DatabaseService.java
+++ b/backend/src/main/java/io/diveni/backend/service/DatabaseService.java
@@ -60,6 +60,12 @@ public class DatabaseService {
 
   public Session saveSession(Session session) {
     LOGGER.debug("saveSession()");
+    if (session.getVersion() == null && session.getDatabaseID() != null) {
+      // Version was lost during immutable copy — restore from DB for optimistic locking
+      sessionRepo
+          .findById(session.getDatabaseID().toHexString())
+          .ifPresent(current -> session.setVersion(current.getVersion()));
+    }
     return sessionRepo.save(session.setLastModified(new Date()));
   }
 

--- a/backend/src/main/java/io/diveni/backend/service/ai/AiService.java
+++ b/backend/src/main/java/io/diveni/backend/service/ai/AiService.java
@@ -1,3 +1,8 @@
+/*
+  SPDX-License-Identifier: AGPL-3.0-or-later
+  Diveni - The Planing-Poker App
+  Copyright (C) 2022 Diveni Team, AUME-Team 21/22, HTWG Konstanz
+*/
 package io.diveni.backend.service.ai;
 
 import io.diveni.backend.dto.AiServiceResponse;

--- a/backend/src/main/java/io/diveni/backend/service/ai/AiService.java
+++ b/backend/src/main/java/io/diveni/backend/service/ai/AiService.java
@@ -22,8 +22,7 @@ public class AiService {
   @Value("${python_ai_url}")
   private String aiUrl;
 
-  @Autowired
-  private RestTemplate restTemplate;
+  @Autowired private RestTemplate restTemplate;
 
   @PostConstruct
   public void logConfig() {

--- a/backend/src/main/java/io/diveni/backend/service/ai/AiService.java
+++ b/backend/src/main/java/io/diveni/backend/service/ai/AiService.java
@@ -1,12 +1,11 @@
 package io.diveni.backend.service.ai;
 
-import com.google.gson.Gson;
 import io.diveni.backend.dto.AiServiceResponse;
 import io.diveni.backend.dto.GptConfidentialData;
 import jakarta.annotation.PostConstruct;
-import org.json.JSONObject;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.*;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClientException;
@@ -23,6 +22,9 @@ public class AiService {
   @Value("${python_ai_url}")
   private String aiUrl;
 
+  @Autowired
+  private RestTemplate restTemplate;
+
   @PostConstruct
   public void logConfig() {
     LOGGER.info("Url to Server is: " + aiUrl);
@@ -31,9 +33,6 @@ public class AiService {
   public ResponseEntity<String> executeRequest(String url, HttpMethod method, Object body)
       throws RestClientException {
     LOGGER.debug("--> executeRequest()");
-    // Create a RestTemplate object
-    RestTemplate restTemplate = new RestTemplate();
-    // Set the headers for the request
     HttpHeaders headers = new HttpHeaders();
     headers.setAccept(List.of(MediaType.APPLICATION_JSON));
     headers.setContentType(MediaType.APPLICATION_JSON);
@@ -48,7 +47,7 @@ public class AiService {
     content.put("name", data.getTitle());
     content.put("confidential_data", data.getConfidentialData().toMap());
     ResponseEntity<String> response =
-        executeRequest(aiUrl + "/improve-title", HttpMethod.POST, new Gson().toJson(content));
+        executeRequest(aiUrl + "/improve-title", HttpMethod.POST, content);
     LOGGER.debug("<-- improveTitle()");
     return response;
   }
@@ -61,7 +60,7 @@ public class AiService {
     content.put("confidential_data", data.getConfidentialData().toMap());
     content.put("language", data.getLanguage());
     ResponseEntity<String> response =
-        executeRequest(aiUrl + "/improve-description", HttpMethod.POST, new Gson().toJson(content));
+        executeRequest(aiUrl + "/improve-description", HttpMethod.POST, content);
     LOGGER.debug("<-- improveDescription()");
     return response;
   }
@@ -74,7 +73,7 @@ public class AiService {
     content.put("confidential_data", data.getConfidentialData().toMap());
     content.put("language", data.getLanguage());
     ResponseEntity<String> response =
-        executeRequest(aiUrl + "/grammar-check", HttpMethod.POST, new Gson().toJson(content));
+        executeRequest(aiUrl + "/grammar-check", HttpMethod.POST, content);
     LOGGER.debug("<-- grammarCheck()");
     return response;
   }
@@ -87,7 +86,7 @@ public class AiService {
     content.put("confidential_data", data.getConfidentialData().toMap());
     content.put("voteSet", data.getVoteSet());
     ResponseEntity<String> response =
-        executeRequest(aiUrl + "/estimate-user-story", HttpMethod.POST, new Gson().toJson(content));
+        executeRequest(aiUrl + "/estimate-user-story", HttpMethod.POST, content);
     LOGGER.debug("<-- estimateUserStory()");
     return response;
   }
@@ -100,7 +99,7 @@ public class AiService {
     content.put("confidential_data", data.getConfidentialData().toMap());
     content.put("language", data.getLanguage());
     ResponseEntity<String> response =
-        executeRequest(aiUrl + "/split-user-story", HttpMethod.POST, new Gson().toJson(content));
+        executeRequest(aiUrl + "/split-user-story", HttpMethod.POST, content);
     LOGGER.debug("<-- splitUserStory()");
     return response;
   }
@@ -113,20 +112,26 @@ public class AiService {
     content.put("confidential_data", data.getConfidentialData().toMap());
     content.put("language", data.getLanguage());
     ResponseEntity<String> response =
-        executeRequest(aiUrl + "/mark-description", HttpMethod.POST, new Gson().toJson(content));
+        executeRequest(aiUrl + "/mark-description", HttpMethod.POST, content);
     LOGGER.debug("<-- markDescription");
     return response;
   }
 
+  @SuppressWarnings("unchecked")
   public ResponseEntity<AiServiceResponse> ensureServiceAndApiKey() {
     LOGGER.debug("--> ensureServiceAndApiKey()");
     AiServiceResponse result;
     try {
-      ResponseEntity<String> response =
-          executeRequest(aiUrl + "/check-api-key", HttpMethod.GET, null);
+      ResponseEntity<Map<String, Object>> response =
+          restTemplate.exchange(
+              aiUrl + "/check-api-key",
+              HttpMethod.GET,
+              null,
+              (Class<Map<String, Object>>) (Class<?>) Map.class);
+      Map<String, Object> body = response.getBody();
       result =
           AiServiceResponse.builder()
-              .apiKeyValid(new JSONObject(response.getBody()).getBoolean("has_api_key"))
+              .apiKeyValid(body != null && Boolean.TRUE.equals(body.get("has_api_key")))
               .serviceAvailable(response.getStatusCode().is2xxSuccessful())
               .build();
     } catch (RestClientException rce) {

--- a/backend/src/test/java/io/diveni/backend/config/RestTemplateConfigTest.java
+++ b/backend/src/test/java/io/diveni/backend/config/RestTemplateConfigTest.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.web.client.RestTemplate;
 
-
 @SpringBootTest
 public class RestTemplateConfigTest {
 

--- a/backend/src/test/java/io/diveni/backend/config/RestTemplateConfigTest.java
+++ b/backend/src/test/java/io/diveni/backend/config/RestTemplateConfigTest.java
@@ -1,0 +1,26 @@
+/*
+  SPDX-License-Identifier: AGPL-3.0-or-later
+  Diveni - The Planing-Poker App
+  Copyright (C) 2022 Diveni Team, AUME-Team 21/22, HTWG Konstanz
+*/
+package io.diveni.backend.config;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.web.client.RestTemplate;
+
+import lombok.val;
+
+@SpringBootTest
+public class RestTemplateConfigTest {
+
+  @Autowired private RestTemplate restTemplate;
+
+  @Test
+  public void restTemplateBean_isConfigured() {
+    assertNotNull(restTemplate, "RestTemplate bean should be loaded");
+  }
+}

--- a/backend/src/test/java/io/diveni/backend/config/RestTemplateConfigTest.java
+++ b/backend/src/test/java/io/diveni/backend/config/RestTemplateConfigTest.java
@@ -12,7 +12,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.web.client.RestTemplate;
 
-import lombok.val;
 
 @SpringBootTest
 public class RestTemplateConfigTest {

--- a/backend/src/test/java/io/diveni/backend/model/SessionTest.java
+++ b/backend/src/test/java/io/diveni/backend/model/SessionTest.java
@@ -557,12 +557,40 @@ public class SessionTest {
 
   @Test
   public void versionField_isExcludedFromEqualsAndHashCode() {
-    val session1 = new Session(
-        null, null, null, null, null, new ArrayList<>(), new HashMap<>(), new ArrayList<>(),
-        SessionState.WAITING_FOR_MEMBERS, null, null, null, null, false, null);
-    val session2 = new Session(
-        null, null, null, null, null, new ArrayList<>(), new HashMap<>(), new ArrayList<>(),
-        SessionState.WAITING_FOR_MEMBERS, null, null, null, null, false, null);
+    val session1 =
+        new Session(
+            null,
+            null,
+            null,
+            null,
+            null,
+            new ArrayList<>(),
+            new HashMap<>(),
+            new ArrayList<>(),
+            SessionState.WAITING_FOR_MEMBERS,
+            null,
+            null,
+            null,
+            null,
+            false,
+            null);
+    val session2 =
+        new Session(
+            null,
+            null,
+            null,
+            null,
+            null,
+            new ArrayList<>(),
+            new HashMap<>(),
+            new ArrayList<>(),
+            SessionState.WAITING_FOR_MEMBERS,
+            null,
+            null,
+            null,
+            null,
+            false,
+            null);
 
     session1.setVersion(1);
     session2.setVersion(5);

--- a/backend/src/test/java/io/diveni/backend/model/SessionTest.java
+++ b/backend/src/test/java/io/diveni/backend/model/SessionTest.java
@@ -554,4 +554,20 @@ public class SessionTest {
 
     assertEquals("10", result.getHostEstimation().getHostEstimation());
   }
+
+  @Test
+  public void versionField_isExcludedFromEqualsAndHashCode() {
+    val session1 = new Session(
+        null, null, null, null, null, new ArrayList<>(), new HashMap<>(), new ArrayList<>(),
+        SessionState.WAITING_FOR_MEMBERS, null, null, null, null, false, null);
+    val session2 = new Session(
+        null, null, null, null, null, new ArrayList<>(), new HashMap<>(), new ArrayList<>(),
+        SessionState.WAITING_FOR_MEMBERS, null, null, null, null, false, null);
+
+    session1.setVersion(1);
+    session2.setVersion(5);
+
+    assertEquals(session1, session2, "Sessions with different versions should be equal");
+    assertEquals(session1.hashCode(), session2.hashCode());
+  }
 }

--- a/backend/src/test/java/io/diveni/backend/service/DatabaseServiceTest.java
+++ b/backend/src/test/java/io/diveni/backend/service/DatabaseServiceTest.java
@@ -1,0 +1,173 @@
+/*
+  SPDX-License-Identifier: AGPL-3.0-or-later
+  Diveni - The Planing-Poker App
+  Copyright (C) 2022 Diveni Team, AUME-Team 21/22, HTWG Konstanz
+*/
+package io.diveni.backend.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.UUID;
+
+import io.diveni.backend.Utils;
+import io.diveni.backend.model.Member;
+import io.diveni.backend.model.Session;
+import io.diveni.backend.model.SessionState;
+import org.bson.types.ObjectId;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import lombok.val;
+
+@SpringBootTest
+public class DatabaseServiceTest {
+
+  @Autowired private DatabaseService databaseService;
+
+  private Session createMinimalSession() {
+    return new Session(
+        new ObjectId(),
+        Utils.generateRandomID(),
+        Utils.generateRandomID(),
+        null,
+        UUID.randomUUID(),
+        new ArrayList<Member>(),
+        new HashMap<>(),
+        new ArrayList<>(),
+        SessionState.WAITING_FOR_MEMBERS,
+        null,
+        null,
+        null,
+        LocalDate.now(),
+        false,
+        null);
+  }
+
+  @Test
+  public void saveSession_assignsVersion() {
+    val session = createMinimalSession();
+    val saved = databaseService.saveSession(session);
+    assertNotNull(saved.getVersion(), "First save should assign a version");
+  }
+
+  @Test
+  public void saveSession_incrementsVersionOnUpdate() {
+    val session = createMinimalSession();
+    val firstSave = databaseService.saveSession(session);
+    Integer firstVersion = firstSave.getVersion();
+
+    // Modify and save again via the returned session (has version preserved)
+    val modified = firstSave.setLastModified(new java.util.Date());
+    val secondSave = databaseService.saveSession(modified);
+    assertNotNull(secondSave.getVersion());
+    assertTrue(
+        secondSave.getVersion() > firstVersion,
+        "Version should increment on subsequent saves");
+  }
+
+  @Test
+  public void saveSession_restoresVersionFromDb() {
+    val session = createMinimalSession();
+    val saved = databaseService.saveSession(session);
+    Integer expectedVersion = saved.getVersion();
+
+    // Create a fresh session with same databaseID but null version
+    // (simulates what happens after immutable copy in mutation methods)
+    val updatedMembers = new ArrayList<>(saved.getMembers());
+    updatedMembers.add(new Member(Utils.generateRandomID(), "Test", null, null, null));
+    Session versionlessCopy =
+        new Session(
+            saved.getDatabaseID(),
+            saved.getSessionID(),
+            saved.getAdminID(),
+            saved.getSessionConfig(),
+            saved.getAdminCookie(),
+            updatedMembers,
+            saved.getMemberVoted(),
+            saved.getCurrentHighlights(),
+            saved.getSessionState(),
+            null,
+            saved.getAccessToken(),
+            saved.getTimerTimestamp(),
+            saved.getCreationTime(),
+            saved.isHostVoting(),
+            saved.getHostEstimation());
+
+    val restored = databaseService.saveSession(versionlessCopy);
+    assertNotNull(restored.getVersion());
+    assertTrue(
+        restored.getVersion() > expectedVersion,
+        "Version should increment even when starting from a versionless copy");
+  }
+
+  @Test
+  public void deleteSession_deletesSuccessfully() {
+    val session = createMinimalSession();
+    val saved = databaseService.saveSession(session);
+
+    // Delete via the saved session (has version)
+    databaseService.deleteSession(saved);
+
+    // Verify it's gone
+    val deleted =
+        databaseService.getSessionByID(saved.getSessionID());
+    assertTrue(deleted.isEmpty(), "Session should be deleted");
+  }
+
+  @Test
+  public void deleteSession_worksWithVersionlessCopy() {
+    val session = createMinimalSession();
+    val saved = databaseService.saveSession(session);
+
+    // Create a versionless copy (simulates immutable copy pattern)
+    Session versionlessCopy =
+        new Session(
+            saved.getDatabaseID(),
+            saved.getSessionID(),
+            saved.getAdminID(),
+            saved.getSessionConfig(),
+            saved.getAdminCookie(),
+            saved.getMembers(),
+            saved.getMemberVoted(),
+            saved.getCurrentHighlights(),
+            saved.getSessionState(),
+            null,
+            saved.getAccessToken(),
+            saved.getTimerTimestamp(),
+            saved.getCreationTime(),
+            saved.isHostVoting(),
+            saved.getHostEstimation());
+
+    // Should succeed due to version restoration in deleteSession
+    databaseService.deleteSession(versionlessCopy);
+
+    val deleted =
+        databaseService.getSessionByID(saved.getSessionID());
+    assertTrue(deleted.isEmpty(), "Session should be deleted");
+  }
+
+  @Test
+  public void saveSession_handlesConcurrentSave() {
+    // Verify that two saves on the same session don't throw
+    val session = createMinimalSession();
+    val firstSave = databaseService.saveSession(session);
+
+    // Simulate two updates via the same correctly-versioned object
+    val update1 =
+        firstSave.setLastModified(new java.util.Date());
+    val result1 = databaseService.saveSession(update1);
+    assertNotNull(result1.getVersion());
+
+    val update2 =
+        result1.setLastModified(new java.util.Date());
+    val result2 = databaseService.saveSession(update2);
+    assertNotNull(result2.getVersion());
+    assertTrue(result2.getVersion() > result1.getVersion());
+  }
+}

--- a/backend/src/test/java/io/diveni/backend/service/DatabaseServiceTest.java
+++ b/backend/src/test/java/io/diveni/backend/service/DatabaseServiceTest.java
@@ -94,7 +94,7 @@ public class DatabaseServiceTest {
             saved.getAccessToken(),
             saved.getTimerTimestamp(),
             saved.getCreationTime(),
-            saved.isHostVoting(),
+            saved.getHostVoting(),
             saved.getHostEstimation());
 
     val restored = databaseService.saveSession(versionlessCopy);
@@ -138,7 +138,7 @@ public class DatabaseServiceTest {
             saved.getAccessToken(),
             saved.getTimerTimestamp(),
             saved.getCreationTime(),
-            saved.isHostVoting(),
+            saved.getHostVoting(),
             saved.getHostEstimation());
 
     // Should succeed due to version restoration in deleteSession

--- a/backend/src/test/java/io/diveni/backend/service/DatabaseServiceTest.java
+++ b/backend/src/test/java/io/diveni/backend/service/DatabaseServiceTest.java
@@ -5,7 +5,6 @@
 */
 package io.diveni.backend.service;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -67,8 +66,7 @@ public class DatabaseServiceTest {
     val secondSave = databaseService.saveSession(modified);
     assertNotNull(secondSave.getVersion());
     assertTrue(
-        secondSave.getVersion() > firstVersion,
-        "Version should increment on subsequent saves");
+        secondSave.getVersion() > firstVersion, "Version should increment on subsequent saves");
   }
 
   @Test
@@ -115,8 +113,7 @@ public class DatabaseServiceTest {
     databaseService.deleteSession(saved);
 
     // Verify it's gone
-    val deleted =
-        databaseService.getSessionByID(saved.getSessionID());
+    val deleted = databaseService.getSessionByID(saved.getSessionID());
     assertTrue(deleted.isEmpty(), "Session should be deleted");
   }
 
@@ -147,8 +144,7 @@ public class DatabaseServiceTest {
     // Should succeed due to version restoration in deleteSession
     databaseService.deleteSession(versionlessCopy);
 
-    val deleted =
-        databaseService.getSessionByID(saved.getSessionID());
+    val deleted = databaseService.getSessionByID(saved.getSessionID());
     assertTrue(deleted.isEmpty(), "Session should be deleted");
   }
 
@@ -159,13 +155,11 @@ public class DatabaseServiceTest {
     val firstSave = databaseService.saveSession(session);
 
     // Simulate two updates via the same correctly-versioned object
-    val update1 =
-        firstSave.setLastModified(new java.util.Date());
+    val update1 = firstSave.setLastModified(new java.util.Date());
     val result1 = databaseService.saveSession(update1);
     assertNotNull(result1.getVersion());
 
-    val update2 =
-        result1.setLastModified(new java.util.Date());
+    val update2 = result1.setLastModified(new java.util.Date());
     val result2 = databaseService.saveSession(update2);
     assertNotNull(result2.getVersion());
     assertTrue(result2.getVersion() > result1.getVersion());


### PR DESCRIPTION
- **#1202** — RestTemplate connection pooling (Apache HttpClient 5, 200 max connections) + remove manual JSON serialization in AiService  
- **#1203** — Session: attempted `@Builder` but conflicts with `@Version` field (deferred: mutation methods need toBuilder() refactoring first)  
- **#1204** — Optimistic locking: `@Version` field on Session + version restore in saveSession for multi-instance safety  
- **#1205** — Move `/get-timer-value` REST endpoint from WebsocketController to RoutesController  
- **#1206** — Remove duplicate Springdoc 1.x dependency (`springdoc-openapi-ui:1.8.0`)  
- **#1207** — Upgrade GPT model: `gpt-3.5-turbo-instruct` → `gpt-4o-mini`, migrate to Chat Completions API  

Fixes #1202, #1205, #1206, #1207 (partially addresses #1203, #1204)